### PR TITLE
Add ChatGPT assistant integration and CI pipeline

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,33 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ main, work ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Assemble debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Upload debug APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: hub-debug-apk
+          path: hub/build/outputs/apk/debug/*.apk

--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ The **hub** module contains the application for running the G1 service and manag
 The application can seamlessly and reliably discover, connect and disconnect, and send commands to glasses.
 It must be running on your phone and connected to the glasses for any apps using the client library to talk to them.
 
+### Assistant mode
+
+The Hub application now ships with an **Assistant** tab that talks directly to ChatGPT.
+Bring your own OpenAI API key from the **Settings** tab and the app will store it in encrypted SharedPreferences.
+Responses are auto-trimmed to five 40-character lines before being streamed to the connected glasses so the HUD stays readable.
+Two starter personalities (Ershin and Fou-Lu) are available to quickly change tone and verbosity.
+
 *(more details coming soon)*
 
 ## Client

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,9 @@ datastore = "1.1.2"
 basisClient = "1.1.1"
 basisService = "1.1.0"
 materialIcons = "1.7.7"
+securityCrypto = "1.1.0-alpha06"
+okhttp = "4.12.0"
+lifecycleRuntimeCompose = "2.8.7"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -41,6 +44,10 @@ androidx-datastore = { group = "androidx.datastore", name = "datastore-preferenc
 basis-client = { group = "io.texne.g1.basis", name = "client", version.ref = "basisClient"}
 basis-service = { group = "io.texne.g1.basis", name = "service", version.ref = "basisService"}
 androidx-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "materialIcons"}
+androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
+okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
+okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntimeCompose" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/hub/build.gradle.kts
+++ b/hub/build.gradle.kts
@@ -57,10 +57,15 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.icons.extended)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.hilt.android)
     implementation(libs.hilt.navigation.compose)
     implementation(project(":service"))
     implementation(project(":client"))
+    implementation(libs.androidx.security.crypto)
+    implementation(libs.okhttp)
+    implementation(libs.okhttp.logging)
 
     kapt(libs.hilt.android.compiler)
 }

--- a/hub/build.gradle.kts
+++ b/hub/build.gradle.kts
@@ -24,6 +24,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.14"

--- a/hub/src/main/java/io/texne/g1/hub/G1HubApplication.kt
+++ b/hub/src/main/java/io/texne/g1/hub/G1HubApplication.kt
@@ -2,13 +2,35 @@ package io.texne.g1.hub
 
 import android.app.Application
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.HiltAndroidApp
 import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import javax.inject.Singleton
+
+import io.texne.g1.hub.BuildConfig
 
 @Module
 @InstallIn(SingletonComponent::class)
-object GlobalModule
+object GlobalModule {
+    @Provides
+    @Singleton
+    fun provideOkHttpClient(): OkHttpClient {
+        val logging = HttpLoggingInterceptor().apply {
+            level = if (BuildConfig.DEBUG) {
+                HttpLoggingInterceptor.Level.BASIC
+            } else {
+                HttpLoggingInterceptor.Level.NONE
+            }
+        }
+
+        return OkHttpClient.Builder()
+            .addInterceptor(logging)
+            .build()
+    }
+}
 
 @HiltAndroidApp
 class G1HubApplication: Application()

--- a/hub/src/main/java/io/texne/g1/hub/ai/ChatGptRepository.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ai/ChatGptRepository.kt
@@ -1,0 +1,110 @@
+package io.texne.g1.hub.ai
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONArray
+import org.json.JSONObject
+
+@Singleton
+class ChatGptRepository @Inject constructor(
+    private val preferences: ChatPreferences,
+    private val httpClient: OkHttpClient
+) {
+    data class ChatMessageData(
+        val role: String,
+        val content: String
+    )
+
+    fun observeApiKey(): StateFlow<String?> = preferences.observeApiKey()
+
+    fun currentApiKey(): String? = preferences.getApiKey()
+
+    suspend fun updateApiKey(key: String?) = preferences.setApiKey(key)
+
+    suspend fun requestChatCompletion(
+        persona: ChatPersona,
+        history: List<ChatMessageData>
+    ): Result<String> = withContext(Dispatchers.IO) {
+        val apiKey = preferences.getApiKey()
+            ?: return@withContext Result.failure(IllegalStateException("Missing ChatGPT API key"))
+
+        val messages = JSONArray().apply {
+            put(JSONObject().apply {
+                put("role", "system")
+                put("content", persona.systemPrompt)
+            })
+            history.forEach { message ->
+                put(JSONObject().apply {
+                    put("role", message.role)
+                    put("content", message.content)
+                })
+            }
+        }
+
+        val requestJson = JSONObject().apply {
+            put("model", DEFAULT_MODEL)
+            put("temperature", persona.temperature)
+            put("max_tokens", persona.maxTokens)
+            put("messages", messages)
+        }
+
+        val requestBody = requestJson
+            .toString()
+            .toRequestBody("application/json; charset=utf-8".toMediaType())
+
+        val request = Request.Builder()
+            .url(ENDPOINT)
+            .addHeader("Authorization", "Bearer $apiKey")
+            .addHeader("Content-Type", "application/json")
+            .post(requestBody)
+            .build()
+
+        try {
+            httpClient.newCall(request).execute().use { response ->
+                val body = response.body?.string()
+                    ?: return@withContext Result.failure(IllegalStateException("Empty response from ChatGPT"))
+
+                if (!response.isSuccessful) {
+                    val errorMessage = runCatching {
+                        JSONObject(body).optJSONObject("error")?.optString("message")
+                    }.getOrNull()
+
+                    return@withContext Result.failure(
+                        IllegalStateException(errorMessage ?: "ChatGPT request failed with ${response.code}")
+                    )
+                }
+
+                val content = runCatching {
+                    val json = JSONObject(body)
+                    val choices = json.optJSONArray("choices")
+                    if (choices != null && choices.length() > 0) {
+                        val first = choices.getJSONObject(0)
+                        first.optJSONObject("message")?.optString("content")
+                    } else {
+                        null
+                    }
+                }.getOrNull()
+
+                if (content.isNullOrBlank()) {
+                    return@withContext Result.failure(IllegalStateException("ChatGPT response did not contain any content"))
+                }
+
+                Result.success(content.trim())
+            }
+        } catch (throwable: Throwable) {
+            Result.failure(throwable)
+        }
+    }
+
+    companion object {
+        private const val ENDPOINT = "https://api.openai.com/v1/chat/completions"
+        private const val DEFAULT_MODEL = "gpt-4o-mini"
+    }
+}

--- a/hub/src/main/java/io/texne/g1/hub/ai/ChatPersona.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ai/ChatPersona.kt
@@ -1,0 +1,31 @@
+package io.texne.g1.hub.ai
+
+data class ChatPersona(
+    val id: String,
+    val displayName: String,
+    val description: String,
+    val systemPrompt: String,
+    val temperature: Double = 0.7,
+    val maxTokens: Int = 220,
+    val hudHoldMillis: Long = 5_000L
+)
+
+object ChatPersonas {
+    val Ershin = ChatPersona(
+        id = "ershin",
+        displayName = "Ershin",
+        description = "Friendly navigator that keeps answers short and upbeat.",
+        systemPrompt = "You are Ershin, an energetic AI guide who helps the wearer of Even Realities G1 smart glasses. " +
+            "Reply in at most three concise sentences. Prefer actionable details."
+    )
+
+    val FouLu = ChatPersona(
+        id = "fou_lu",
+        displayName = "Fou-Lu",
+        description = "Stoic strategist. Precise, formal, and minimal wording.",
+        systemPrompt = "You are Fou-Lu, a strategic partner for an augmented reality heads-up display. " +
+            "Respond in clipped, confident phrases no longer than 35 characters per sentence."
+    )
+
+    val all = listOf(Ershin, FouLu)
+}

--- a/hub/src/main/java/io/texne/g1/hub/ai/ChatPreferences.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ai/ChatPreferences.kt
@@ -1,0 +1,63 @@
+package io.texne.g1.hub.ai
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withContext
+
+@Singleton
+class ChatPreferences @Inject constructor(
+    @ApplicationContext context: Context
+) {
+    private val masterKey = MasterKey.Builder(context)
+        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+        .build()
+
+    private val sharedPreferences: SharedPreferences = EncryptedSharedPreferences.create(
+        context,
+        PREF_NAME,
+        masterKey,
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+    )
+
+    private val apiKeyFlow = MutableStateFlow(sharedPreferences.getString(KEY_API, null))
+
+    private val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+        if (key == KEY_API) {
+            apiKeyFlow.value = sharedPreferences.getString(KEY_API, null)
+        }
+    }
+
+    init {
+        sharedPreferences.registerOnSharedPreferenceChangeListener(listener)
+    }
+
+    fun observeApiKey(): StateFlow<String?> = apiKeyFlow.asStateFlow()
+
+    fun getApiKey(): String? = sharedPreferences.getString(KEY_API, null)
+
+    suspend fun setApiKey(key: String?) = withContext(Dispatchers.IO) {
+        sharedPreferences.edit(commit = true) {
+            if (key.isNullOrBlank()) {
+                remove(KEY_API)
+            } else {
+                putString(KEY_API, key.trim())
+            }
+        }
+    }
+
+    companion object {
+        private const val PREF_NAME = "chat_gpt"
+        private const val KEY_API = "openai_api_key"
+    }
+}

--- a/hub/src/main/java/io/texne/g1/hub/ai/HudFormatter.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ai/HudFormatter.kt
@@ -1,0 +1,92 @@
+package io.texne.g1.hub.ai
+
+object HudFormatter {
+    data class Result(
+        val lines: List<String>,
+        val truncated: Boolean
+    )
+
+    fun format(text: String, maxLines: Int = 5, maxCharsPerLine: Int = 40): Result {
+        val normalized = text
+            .replace("\n", " ")
+            .replace("\s+".toRegex(), " ")
+            .trim()
+
+        if (normalized.isEmpty()) {
+            return Result(lines = listOf(""), truncated = false)
+        }
+
+        val lines = mutableListOf<String>()
+        val current = StringBuilder()
+        var truncated = false
+
+        val words = normalized.split(" ")
+        for (word in words) {
+            val candidate = if (current.isEmpty()) word else "${current} $word"
+            if (candidate.length <= maxCharsPerLine) {
+                current.clear()
+                current.append(candidate)
+            } else {
+                if (current.isNotEmpty()) {
+                    lines += current.toString()
+                    current.clear()
+                }
+                if (word.length > maxCharsPerLine) {
+                    val chunks = word.chunked(maxCharsPerLine)
+                    for (chunk in chunks.dropLast(1)) {
+                        lines += chunk
+                        if (lines.size == maxLines) {
+                            truncated = true
+                            break
+                        }
+                    }
+                    if (truncated) {
+                        break
+                    }
+                    current.append(chunks.last())
+                } else {
+                    current.append(word)
+                }
+            }
+
+            if (lines.size == maxLines) {
+                truncated = true
+                break
+            }
+        }
+
+        if (!truncated && current.isNotEmpty()) {
+            lines += current.toString()
+        } else if (truncated && lines.size == maxLines - 1 && current.isNotEmpty()) {
+            lines += current.toString()
+        }
+
+        if (lines.isEmpty() && current.isNotEmpty()) {
+            lines += current.toString()
+        }
+
+        if (lines.size > maxLines) {
+            truncated = true
+        }
+
+        val trimmedLines = if (lines.size > maxLines) {
+            lines.take(maxLines)
+        } else {
+            lines
+        }
+
+        val output = if (truncated && trimmedLines.isNotEmpty()) {
+            val last = trimmedLines.last()
+            val adjusted = if (last.length >= maxCharsPerLine) {
+                last.take(maxCharsPerLine - 1) + "…"
+            } else {
+                (last + " …").take(maxCharsPerLine)
+            }
+            trimmedLines.dropLast(1) + adjusted
+        } else {
+            trimmedLines
+        }
+
+        return Result(lines = output, truncated = truncated)
+    }
+}

--- a/hub/src/main/java/io/texne/g1/hub/ai/HudFormatter.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ai/HudFormatter.kt
@@ -1,6 +1,8 @@
 package io.texne.g1.hub.ai
 
 object HudFormatter {
+    private val whitespaceRegex = Regex("""\s+""")
+
     data class Result(
         val lines: List<String>,
         val truncated: Boolean
@@ -8,8 +10,8 @@ object HudFormatter {
 
     fun format(text: String, maxLines: Int = 5, maxCharsPerLine: Int = 40): Result {
         val normalized = text
-            .replace("\n", " ")
-            .replace("\s+".toRegex(), " ")
+            .replace('\n', ' ')
+            .replace(whitespaceRegex, " ")
             .trim()
 
         if (normalized.isEmpty()) {

--- a/hub/src/main/java/io/texne/g1/hub/model/Repository.kt
+++ b/hub/src/main/java/io/texne/g1/hub/model/Repository.kt
@@ -19,17 +19,45 @@ class Repository @Inject constructor(
         return true
     }
 
-    fun unbindService() =
-        service.close()
+    fun unbindService() {
+        if(::service.isInitialized) {
+            service.close()
+        }
+    }
 
-    fun startLooking() =
-        service.lookForGlasses()
+    fun startLooking() {
+        if(::service.isInitialized) {
+            service.lookForGlasses()
+        }
+    }
 
     suspend fun connectGlasses(id: String) =
         service.connect(id)
 
     fun disconnectGlasses(id: String) =
         service.disconnect(id)
+
+    fun connectedGlasses(): List<G1ServiceCommon.Glasses> =
+        if(::service.isInitialized) service.listConnectedGlasses() else emptyList()
+
+    suspend fun displayCenteredOnConnectedGlasses(
+        lines: List<String>,
+        holdMillis: Long? = 5_000L
+    ): Boolean {
+        if(!::service.isInitialized) {
+            return false
+        }
+        val connected = service.listConnectedGlasses().firstOrNull() ?: return false
+        return service.displayCentered(connected.id, lines, holdMillis)
+    }
+
+    suspend fun stopDisplayingOnConnectedGlasses(): Boolean {
+        if(!::service.isInitialized) {
+            return false
+        }
+        val connected = service.listConnectedGlasses().firstOrNull() ?: return false
+        return service.stopDisplaying(connected.id)
+    }
 
     private lateinit var service: G1ServiceManager
 }

--- a/hub/src/main/java/io/texne/g1/hub/ui/ApplicationFrame.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/ApplicationFrame.kt
@@ -11,9 +11,15 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -24,58 +30,106 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import io.texne.g1.hub.ui.chat.ChatScreen
+import io.texne.g1.hub.ui.settings.SettingsScreen
 
 @Composable
 fun ApplicationFrame() {
     val viewModel = hiltViewModel<ApplicationViewModel>()
     val state = viewModel.state.collectAsState().value
 
+    var selectedSection by rememberSaveable { mutableStateOf(AppSection.GLASSES) }
+
     Column(
         modifier = Modifier.fillMaxSize()
     ) {
-        Header()
+        Header(
+            selectedSection = selectedSection,
+            onSectionSelected = { selectedSection = it }
+        )
 
         val connectedGlasses = state?.connectedGlasses
 
-        if (connectedGlasses != null) {
-            GlassesScreen(
-                connectedGlasses,
-                { viewModel.disconnect(connectedGlasses.id) }
-            )
-        } else {
-            ScannerScreen(
-                scanning = state?.scanning == true,
-                error = state?.error == true,
-                nearbyGlasses = state?.nearbyGlasses,
-                scan = { viewModel.scan() },
-                connect = { viewModel.connect(it) },
-            )
+        when (selectedSection) {
+            AppSection.GLASSES -> {
+                if (connectedGlasses != null) {
+                    GlassesScreen(
+                        connectedGlasses,
+                        { viewModel.disconnect(connectedGlasses.id) }
+                    )
+                } else {
+                    ScannerScreen(
+                        scanning = state?.scanning == true,
+                        error = state?.error == true,
+                        nearbyGlasses = state?.nearbyGlasses,
+                        scan = { viewModel.scan() },
+                        connect = { viewModel.connect(it) },
+                    )
+                }
+            }
+            AppSection.ASSISTANT -> {
+                ChatScreen(
+                    connectedGlassesName = connectedGlasses?.name,
+                    onNavigateToSettings = { selectedSection = AppSection.SETTINGS }
+                )
+            }
+            AppSection.SETTINGS -> {
+                SettingsScreen()
+            }
         }
     }
 }
 
 @Composable
-fun Header() {
-    Box(
-        modifier = Modifier.fillMaxWidth().height(128.dp),
-        contentAlignment = Alignment.Center
-    ) {
-        Column(
-            horizontalAlignment = Alignment.Start,
-            verticalArrangement = Arrangement.spacedBy((-8).dp)
+fun Header(
+    selectedSection: AppSection,
+    onSectionSelected: (AppSection) -> Unit
+) {
+    Column {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(128.dp),
+            contentAlignment = Alignment.Center
         ) {
-            Row(
+            Column(
+                horizontalAlignment = Alignment.Start,
+                verticalArrangement = Arrangement.spacedBy((-8).dp)
             ) {
-                Image(
-                    painter = painterResource(io.texne.g1.basis.service.R.mipmap.ic_service_foreground),
-                    contentDescription = "G1 Hub Logo",
-                    contentScale = ContentScale.Crop,
-                    modifier = Modifier.height(40.dp).width(32.dp)
-                )
-                Text("G1", fontSize = 32.sp, fontWeight = FontWeight.Black, color = Color.Gray, fontStyle = FontStyle.Italic)
-                Text("Hub", fontSize = 32.sp, fontWeight = FontWeight.Bold)
+                Row {
+                    Image(
+                        painter = painterResource(io.texne.g1.basis.service.R.mipmap.ic_service_foreground),
+                        contentDescription = "G1 Hub Logo",
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.height(40.dp).width(32.dp)
+                    )
+                    Text(
+                        "G1",
+                        fontSize = 32.sp,
+                        fontWeight = FontWeight.Black,
+                        color = Color.Gray,
+                        fontStyle = FontStyle.Italic
+                    )
+                    Text("Hub", fontSize = 32.sp, fontWeight = FontWeight.Bold)
+                }
+                Text("A hub for Basis applications", fontSize = 11.sp)
             }
-            Text("A hub for Basis applications", fontSize = 11.sp)
+        }
+
+        TabRow(selectedTabIndex = selectedSection.ordinal) {
+            AppSection.entries.forEach { section ->
+                Tab(
+                    selected = section == selectedSection,
+                    onClick = { onSectionSelected(section) },
+                    text = { Text(section.label) }
+                )
+            }
         }
     }
+}
+
+enum class AppSection(val label: String) {
+    GLASSES("Glasses"),
+    ASSISTANT("Assistant"),
+    SETTINGS("Settings")
 }

--- a/hub/src/main/java/io/texne/g1/hub/ui/chat/ChatScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/chat/ChatScreen.kt
@@ -250,15 +250,11 @@ private fun PersonaSelector(
                         )
                     }
                 } else null,
-                colors = if (selectedPersona) {
-                    FilterChipDefaults.filterChipColors(
-                        containerColor = MaterialTheme.colorScheme.primaryContainer,
-                        labelColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                        leadingIconColor = MaterialTheme.colorScheme.onPrimaryContainer
-                    )
-                } else {
-                    FilterChipDefaults.filterChipColors()
-                }
+                colors = FilterChipDefaults.filterChipColors(
+                    selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                    selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    selectedLeadingIconColor = MaterialTheme.colorScheme.onPrimaryContainer
+                )
             )
         }
     }

--- a/hub/src/main/java/io/texne/g1/hub/ui/chat/ChatScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/chat/ChatScreen.kt
@@ -1,0 +1,367 @@
+package io.texne.g1.hub.ui.chat
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Send
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import io.texne.g1.hub.ai.ChatPersona
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.delay
+
+@Composable
+fun ChatScreen(
+    connectedGlassesName: String?,
+    onNavigateToSettings: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: ChatViewModel = hiltViewModel()
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    ChatContent(
+        state = state,
+        connectedGlassesName = connectedGlassesName,
+        onPersonaSelected = viewModel::onPersonaSelected,
+        onSendPrompt = viewModel::sendPrompt,
+        onNavigateToSettings = onNavigateToSettings,
+        onDismissError = viewModel::clearError,
+        onHudStatusConsumed = viewModel::clearHudStatus
+    )
+}
+
+@Composable
+private fun ChatContent(
+    state: ChatViewModel.State,
+    connectedGlassesName: String?,
+    onPersonaSelected: (ChatPersona) -> Unit,
+    onSendPrompt: (String) -> Unit,
+    onNavigateToSettings: () -> Unit,
+    onDismissError: () -> Unit,
+    onHudStatusConsumed: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var prompt by rememberSaveable { mutableStateOf("") }
+    val listState = rememberLazyListState()
+
+    LaunchedEffect(state.messages.size) {
+        if (state.messages.isNotEmpty()) {
+            listState.animateScrollToItem(state.messages.lastIndex)
+        }
+    }
+
+    LaunchedEffect(state.hudStatus) {
+        if (state.hudStatus is ChatViewModel.HudStatus.Displayed) {
+            delay(3_000)
+            onHudStatusConsumed()
+        }
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(
+            text = "ChatGPT Assistant",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold
+        )
+
+        ConnectionStatus(connectedGlassesName)
+
+        if (!state.apiKeyAvailable) {
+            ApiKeyWarningCard(onNavigateToSettings = onNavigateToSettings)
+        }
+
+        PersonaSelector(
+            personas = state.availablePersonas,
+            selected = state.selectedPersona,
+            onPersonaSelected = onPersonaSelected
+        )
+
+        if (state.errorMessage != null) {
+            ErrorCard(message = state.errorMessage, onDismiss = onDismissError)
+        }
+
+        when (val hudStatus = state.hudStatus) {
+            is ChatViewModel.HudStatus.DisplayFailed -> {
+                HudStatusCard(
+                    text = "Unable to display response on the HUD. Check the connection and try again.",
+                    highlight = true,
+                    onDismiss = onHudStatusConsumed
+                )
+            }
+            is ChatViewModel.HudStatus.Displayed -> {
+                val message = if (hudStatus.truncated) {
+                    "Response shown on the HUD (trimmed to fit)."
+                } else {
+                    "Response sent to the HUD."
+                }
+                HudStatusCard(text = message, onDismiss = onHudStatusConsumed)
+            }
+            ChatViewModel.HudStatus.Idle -> Unit
+        }
+
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+        ) {
+            if (state.isSending) {
+                LoadingIndicator()
+            }
+            LazyColumn(
+                state = listState,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(12.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                if (state.messages.isEmpty()) {
+                    item {
+                        Text(
+                            text = "Ask anything to get started.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                } else {
+                    items(state.messages, key = { it.id }) { message ->
+                        MessageBubble(message = message)
+                    }
+                }
+            }
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.Bottom,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            OutlinedTextField(
+                modifier = Modifier.weight(1f),
+                value = prompt,
+                onValueChange = { prompt = it },
+                label = { Text("Ask the assistant") },
+                maxLines = 3,
+                supportingText = {
+                    if (state.selectedPersona.description.isNotEmpty()) {
+                        Text(
+                            text = state.selectedPersona.description,
+                            style = MaterialTheme.typography.bodySmall,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                }
+            )
+
+            val sendEnabled = prompt.isNotBlank() && state.apiKeyAvailable && !state.isSending
+            IconButton(
+                onClick = {
+                    if (sendEnabled) {
+                        onSendPrompt(prompt.trim())
+                        prompt = ""
+                    }
+                },
+                enabled = sendEnabled
+            ) {
+                Icon(imageVector = Icons.Default.Send, contentDescription = "Send prompt")
+            }
+        }
+    }
+}
+
+@Composable
+private fun ConnectionStatus(connectedGlassesName: String?) {
+    val text = connectedGlassesName?.let { "Connected to $it" }
+        ?: "No glasses connected. Responses will not appear on the HUD."
+    val color = if (connectedGlassesName != null) {
+        MaterialTheme.colorScheme.secondary
+    } else {
+        MaterialTheme.colorScheme.error
+    }
+    Text(text = text, color = color, style = MaterialTheme.typography.bodyMedium)
+}
+
+@Composable
+private fun PersonaSelector(
+    personas: List<ChatPersona>,
+    selected: ChatPersona,
+    onPersonaSelected: (ChatPersona) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        personas.forEach { persona ->
+            val selectedPersona = persona.id == selected.id
+            FilterChip(
+                selected = selectedPersona,
+                onClick = { onPersonaSelected(persona) },
+                label = { Text(persona.displayName) },
+                leadingIcon = if (selectedPersona) {
+                    {
+                        Icon(
+                            imageVector = Icons.Default.Check,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp)
+                        )
+                    }
+                } else null,
+                colors = if (selectedPersona) {
+                    FilterChipDefaults.filterChipColors(
+                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                        labelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                        leadingIconColor = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                } else {
+                    FilterChipDefaults.filterChipColors()
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun MessageBubble(message: ChatViewModel.UiMessage) {
+    val isUser = message.role == ChatViewModel.UiMessage.Role.USER
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = if (isUser) Arrangement.End else Arrangement.Start
+    ) {
+        Surface(
+            shape = MaterialTheme.shapes.large,
+            color = if (isUser) {
+                MaterialTheme.colorScheme.primary
+            } else {
+                MaterialTheme.colorScheme.surface
+            }
+        ) {
+            Text(
+                text = message.text,
+                modifier = Modifier.padding(12.dp),
+                color = if (isUser) {
+                    MaterialTheme.colorScheme.onPrimary
+                } else {
+                    MaterialTheme.colorScheme.onSurface
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun ErrorCard(message: String, onDismiss: () -> Unit) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer)
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(text = "ChatGPT error", style = MaterialTheme.typography.titleSmall)
+            Text(text = message, style = MaterialTheme.typography.bodySmall)
+            TextButton(onClick = onDismiss) {
+                Text("Dismiss")
+            }
+        }
+    }
+}
+
+@Composable
+private fun ApiKeyWarningCard(onNavigateToSettings: () -> Unit) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer)
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text("Add your ChatGPT API key to use the assistant.")
+            Button(onClick = onNavigateToSettings) {
+                Text("Open settings")
+            }
+        }
+    }
+}
+
+@Composable
+private fun HudStatusCard(
+    text: String,
+    onDismiss: () -> Unit,
+    highlight: Boolean = false
+) {
+    val colors = if (highlight) {
+        CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer)
+    } else {
+        CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.tertiaryContainer)
+    }
+    Card(colors = colors) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(text = text, modifier = Modifier.weight(1f))
+            TextButton(onClick = onDismiss) {
+                Text("OK")
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoadingIndicator() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(12.dp),
+        horizontalArrangement = Arrangement.Center
+    ) {
+        CircularProgressIndicator(modifier = Modifier.height(24.dp).width(24.dp))
+    }
+}

--- a/hub/src/main/java/io/texne/g1/hub/ui/settings/SettingsScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/settings/SettingsScreen.kt
@@ -1,0 +1,142 @@
+package io.texne.g1.hub.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+@Composable
+fun SettingsScreen(
+    modifier: Modifier = Modifier,
+    viewModel: SettingsViewModel = hiltViewModel()
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    var revealKey by rememberSaveable { mutableStateOf(false) }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(
+            text = "ChatGPT Integration",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold
+        )
+        Text(
+            text = "Store your personal OpenAI API key locally on this device. The key is encrypted using Android's EncryptedSharedPreferences.",
+            style = MaterialTheme.typography.bodyMedium
+        )
+
+        OutlinedTextField(
+            modifier = Modifier.fillMaxWidth(),
+            value = state.inputKey,
+            onValueChange = viewModel::onInputChanged,
+            label = { Text("OpenAI API Key") },
+            placeholder = { Text("sk-...") },
+            visualTransformation = if (revealKey) VisualTransformation.None else PasswordVisualTransformation(),
+            trailingIcon = {
+                IconButton(onClick = { revealKey = !revealKey }) {
+                    val icon = if (revealKey) Icons.Default.VisibilityOff else Icons.Default.Visibility
+                    Icon(imageVector = icon, contentDescription = if (revealKey) "Hide key" else "Show key")
+                }
+            }
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Button(onClick = viewModel::saveKey, enabled = !state.isSaving) {
+                Text("Save")
+            }
+            TextButton(onClick = viewModel::clearKey, enabled = !state.isSaving) {
+                Text("Clear stored key")
+            }
+            if (state.isSaving) {
+                CircularProgressIndicator(modifier = Modifier.size(24.dp))
+            }
+        }
+
+        val keySummary = if (state.currentKey.isBlank()) {
+            "No key saved yet."
+        } else {
+            val suffix = state.currentKey.takeLast(4)
+            "Stored key detected (…$suffix)"
+        }
+        Text(keySummary, style = MaterialTheme.typography.bodySmall)
+
+        if (state.message != null) {
+            StatusMessage(message = state.message, onDismiss = viewModel::consumeMessage)
+        }
+
+        Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    text = "Usage",
+                    style = MaterialTheme.typography.titleSmall
+                )
+                Text(
+                    text = "Your key is only used for ChatGPT calls made from this device. Remember that usage is billed to your OpenAI account.",
+                    style = MaterialTheme.typography.bodySmall
+                )
+                Text(
+                    text = "Tip: switch personalities in the Assistant tab to tailor responses.",
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatusMessage(message: String, onDismiss: () -> Unit) {
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.tertiaryContainer)) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(message, modifier = Modifier.weight(1f))
+            TextButton(onClick = onDismiss) {
+                Text("OK")
+            }
+        }
+    }
+}

--- a/hub/src/main/java/io/texne/g1/hub/ui/settings/SettingsScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/settings/SettingsScreen.kt
@@ -97,8 +97,8 @@ fun SettingsScreen(
         }
         Text(keySummary, style = MaterialTheme.typography.bodySmall)
 
-        if (state.message != null) {
-            StatusMessage(message = state.message, onDismiss = viewModel::consumeMessage)
+        state.message?.let { message ->
+            StatusMessage(message = message, onDismiss = viewModel::consumeMessage)
         }
 
         Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {

--- a/hub/src/main/java/io/texne/g1/hub/ui/settings/SettingsViewModel.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/settings/SettingsViewModel.kt
@@ -1,0 +1,72 @@
+package io.texne.g1.hub.ui.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.texne.g1.hub.ai.ChatGptRepository
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class SettingsViewModel @Inject constructor(
+    private val chatRepository: ChatGptRepository
+) : ViewModel() {
+
+    data class State(
+        val currentKey: String = "",
+        val inputKey: String = "",
+        val isSaving: Boolean = false,
+        val message: String? = null
+    )
+
+    private val _state = MutableStateFlow(State())
+    val state: StateFlow<State> = _state.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            chatRepository.observeApiKey().collectLatest { key ->
+                _state.update { state ->
+                    state.copy(
+                        currentKey = key.orEmpty(),
+                        inputKey = key.orEmpty()
+                    )
+                }
+            }
+        }
+    }
+
+    fun onInputChanged(value: String) {
+        _state.update { it.copy(inputKey = value) }
+    }
+
+    fun saveKey() {
+        val trimmed = _state.value.inputKey.trim()
+        viewModelScope.launch {
+            _state.update { it.copy(isSaving = true, message = null) }
+            chatRepository.updateApiKey(trimmed.ifBlank { null })
+            val confirmation = if (trimmed.isBlank()) {
+                "API key cleared."
+            } else {
+                "API key saved."
+            }
+            _state.update { it.copy(isSaving = false, message = confirmation) }
+        }
+    }
+
+    fun clearKey() {
+        viewModelScope.launch {
+            _state.update { it.copy(inputKey = "", isSaving = true, message = null) }
+            chatRepository.updateApiKey(null)
+            _state.update { it.copy(isSaving = false, message = "Stored key removed.") }
+        }
+    }
+
+    fun consumeMessage() {
+        _state.update { it.copy(message = null) }
+    }
+}


### PR DESCRIPTION
## Summary
- integrate a BYOK ChatGPT stack with encrypted preferences, OpenAI client, HUD formatter, and Compose UI/view models
- update the hub app frame with Assistant and Settings tabs plus HUD display helpers for connected glasses
- add a GitHub Actions workflow that assembles the debug APK and uploads it as an artifact

## Testing
- `./gradlew assembleDebug` *(fails: Android SDK not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cce04b39648332b7b46ff092ffd1d5