### PR TITLE
Fix debug APK artifact path

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -36,12 +36,12 @@ jobs:
 
       # ✅ List outputs (for debugging)
       - name: List APK outputs
-        run: ls -R app/build/outputs/ || echo "⚠️ No APK outputs found"
+        run: ls -R hub/build/outputs/ || echo "⚠️ No APK outputs found"
 
       # ✅ Upload APK artifact
       - name: Upload Debug APK
         uses: actions/upload-artifact@v4
         with:
-          name: app-debug
-          path: app/build/outputs/apk/debug/app-debug.apk
+          name: hub-debug-apk
+          path: hub/build/outputs/apk/debug/*.apk
           retention-days: 30


### PR DESCRIPTION
## Summary
- point the CI workflow at the hub module build outputs
- upload the generated hub debug APK artifact so it can be downloaded

## Testing
- ./gradlew :hub:assembleDebug *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd09a454088332b0ff0da067db0816