### PR TITLE
Align HUD output with new pagination guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ It must be running on your phone and connected to the glasses for any apps using
 
 The Hub application now ships with an **Assistant** tab that talks directly to ChatGPT.
 Bring your own OpenAI API key from the **Settings** tab and the app will store it in encrypted SharedPreferences.
-Responses are auto-trimmed to five 40-character lines before being streamed to the connected glasses so the HUD stays readable.
+Responses are auto-paginated into four-line, 32-character pages before being streamed to the connected glasses so the monochrome HUD stays glanceable.
 Two starter personalities (Ershin and Fou-Lu) are available to quickly change tone and verbosity.
 
 *(more details coming soon)*

--- a/hub/src/main/java/io/texne/g1/hub/ai/ChatPersona.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ai/ChatPersona.kt
@@ -16,7 +16,7 @@ object ChatPersonas {
         displayName = "Ershin",
         description = "Friendly navigator that keeps answers short and upbeat.",
         systemPrompt = "You are Ershin, an energetic AI guide who helps the wearer of Even Realities G1 smart glasses. " +
-            "Reply in at most three concise sentences. Prefer actionable details."
+            "Reply in three or four upbeat sentences, each under 32 characters. Prefer actionable details."
     )
 
     val FouLu = ChatPersona(
@@ -24,7 +24,7 @@ object ChatPersonas {
         displayName = "Fou-Lu",
         description = "Stoic strategist. Precise, formal, and minimal wording.",
         systemPrompt = "You are Fou-Lu, a strategic partner for an augmented reality heads-up display. " +
-            "Respond in clipped, confident phrases no longer than 35 characters per sentence."
+            "Respond in up to four clipped, confident sentences no longer than 32 characters each."
     )
 
     val all = listOf(Ershin, FouLu)

--- a/hub/src/main/java/io/texne/g1/hub/ui/chat/ChatScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/chat/ChatScreen.kt
@@ -130,10 +130,19 @@ private fun ChatContent(
                 )
             }
             is ChatViewModel.HudStatus.Displayed -> {
-                val message = if (hudStatus.truncated) {
-                    "Response shown on the HUD (trimmed to fit)."
-                } else {
-                    "Response sent to the HUD."
+                val message = when {
+                    hudStatus.pageCount > 1 && hudStatus.truncated ->
+                        "Response paginated across ${hudStatus.pageCount} HUD pages (trimmed to fit width)."
+                    hudStatus.pageCount > 1 ->
+                        if (hudStatus.pageCount == 2) {
+                            "Response paginated across 2 HUD pages."
+                        } else {
+                            "Response paginated across ${hudStatus.pageCount} HUD pages."
+                        }
+                    hudStatus.truncated ->
+                        "Response shown on the HUD (trimmed to fit)."
+                    else ->
+                        "Response sent to the HUD."
                 }
                 HudStatusCard(text = message, onDismiss = onHudStatusConsumed)
             }

--- a/hub/src/main/java/io/texne/g1/hub/ui/chat/ChatViewModel.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/chat/ChatViewModel.kt
@@ -34,7 +34,7 @@ class ChatViewModel @Inject constructor(
 
     sealed interface HudStatus {
         data object Idle : HudStatus
-        data class Displayed(val truncated: Boolean) : HudStatus
+        data class Displayed(val truncated: Boolean, val pageCount: Int) : HudStatus
         data object DisplayFailed : HudStatus
     }
 
@@ -146,14 +146,17 @@ class ChatViewModel @Inject constructor(
 
         viewModelScope.launch {
             val displayed = serviceRepository.displayCenteredOnConnectedGlasses(
-                formatted.lines,
+                formatted.pages,
                 persona.hudHoldMillis
             )
 
             _state.update { state ->
                 state.copy(
                     hudStatus = if (displayed) {
-                        HudStatus.Displayed(formatted.truncated)
+                        HudStatus.Displayed(
+                            truncated = formatted.truncated,
+                            pageCount = formatted.pages.size
+                        )
                     } else {
                         HudStatus.DisplayFailed
                     }


### PR DESCRIPTION
## Summary
- update the HUD formatter to paginate responses into four-line, 32-character pages with ellipsis truncation
- stream multipage responses through the repository and refresh the HUD status messaging to reflect pagination
- tune assistant personas and README copy to match the new heads-up display constraints

## Testing
- ./gradlew :hub:lint *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6e354270833283d28c2efe27d63c