### PR TITLE
Add encrypted todo storage and repository

### DIFF
--- a/hub/src/main/java/io/texne/g1/hub/todo/TodoItem.kt
+++ b/hub/src/main/java/io/texne/g1/hub/todo/TodoItem.kt
@@ -1,0 +1,13 @@
+package io.texne.g1.hub.todo
+
+/**
+ * Represents a task tracked by the heads-up display.
+ */
+data class TodoItem(
+    val id: String,
+    val shortText: String,
+    val fullText: String,
+    val isDone: Boolean,
+    val archivedAt: Long?,
+    val position: Int
+)

--- a/hub/src/main/java/io/texne/g1/hub/todo/TodoPreferences.kt
+++ b/hub/src/main/java/io/texne/g1/hub/todo/TodoPreferences.kt
@@ -1,0 +1,128 @@
+package io.texne.g1.hub.todo
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Log
+import androidx.core.content.edit
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONObject
+
+@Singleton
+class TodoPreferences @Inject constructor(
+    @ApplicationContext context: Context
+) {
+    private val masterKey = MasterKey.Builder(context)
+        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+        .build()
+
+    private val sharedPreferences: SharedPreferences = EncryptedSharedPreferences.create(
+        context,
+        PREF_NAME,
+        masterKey,
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+    )
+
+    suspend fun load(): Snapshot = withContext(Dispatchers.IO) {
+        Snapshot(
+            parseItems(sharedPreferences.getString(KEY_ACTIVE, null)),
+            parseItems(sharedPreferences.getString(KEY_ARCHIVED, null))
+        )
+    }
+
+    suspend fun persist(active: List<TodoItem>, archived: List<TodoItem>) = withContext(Dispatchers.IO) {
+        sharedPreferences.edit(commit = true) {
+            putString(KEY_ACTIVE, encodeItems(active))
+            putString(KEY_ARCHIVED, encodeItems(archived))
+        }
+    }
+
+    private fun parseItems(raw: String?): List<TodoItem> {
+        if (raw.isNullOrBlank()) {
+            return emptyList()
+        }
+
+        return try {
+            val array = JSONArray(raw)
+            buildList {
+                for (index in 0 until array.length()) {
+                    val json = array.optJSONObject(index) ?: continue
+                    val item = json.toTodoItemOrNull() ?: continue
+                    add(item)
+                }
+            }
+        } catch (error: Exception) {
+            Log.e(TAG, "Failed to parse todo list", error)
+            emptyList()
+        }
+    }
+
+    private fun encodeItems(items: List<TodoItem>): String {
+        val array = JSONArray()
+        items.forEach { item ->
+            array.put(item.toJson())
+        }
+        return array.toString()
+    }
+
+    data class Snapshot(
+        val active: List<TodoItem>,
+        val archived: List<TodoItem>
+    )
+
+    private fun JSONObject.toTodoItemOrNull(): TodoItem? {
+        val id = optString(KEY_ID).takeIf { it.isNotBlank() } ?: return null
+        val shortText = optString(KEY_SHORT_TEXT).takeIf { it.isNotBlank() } ?: return null
+        val fullTextRaw = optString(KEY_FULL_TEXT, shortText)
+        val fullText = if (fullTextRaw.isBlank()) shortText else fullTextRaw
+        val isDone = optBoolean(KEY_IS_DONE, false)
+        val archivedAt = if (has(KEY_ARCHIVED_AT) && !isNull(KEY_ARCHIVED_AT)) {
+            optLong(KEY_ARCHIVED_AT)
+        } else {
+            null
+        }
+        val position = optInt(KEY_POSITION, 0)
+
+        return TodoItem(
+            id = id,
+            shortText = shortText,
+            fullText = fullText,
+            isDone = isDone,
+            archivedAt = archivedAt,
+            position = position
+        )
+    }
+
+    private fun TodoItem.toJson(): JSONObject = JSONObject().apply {
+        put(KEY_ID, id)
+        put(KEY_SHORT_TEXT, shortText)
+        put(KEY_FULL_TEXT, fullText)
+        put(KEY_IS_DONE, isDone)
+        if (archivedAt != null) {
+            put(KEY_ARCHIVED_AT, archivedAt)
+        } else {
+            put(KEY_ARCHIVED_AT, JSONObject.NULL)
+        }
+        put(KEY_POSITION, position)
+    }
+
+    companion object {
+        private const val TAG = "TodoPreferences"
+        private const val PREF_NAME = "todo_items"
+        private const val KEY_ACTIVE = "active"
+        private const val KEY_ARCHIVED = "archived"
+        private const val KEY_ID = "id"
+        private const val KEY_SHORT_TEXT = "short_text"
+        private const val KEY_FULL_TEXT = "full_text"
+        private const val KEY_IS_DONE = "is_done"
+        private const val KEY_ARCHIVED_AT = "archived_at"
+        private const val KEY_POSITION = "position"
+    }
+}

--- a/hub/src/main/java/io/texne/g1/hub/todo/TodoRepository.kt
+++ b/hub/src/main/java/io/texne/g1/hub/todo/TodoRepository.kt
@@ -1,0 +1,227 @@
+package io.texne.g1.hub.todo
+
+import java.util.LinkedHashMap
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+@Singleton
+class TodoRepository @Inject constructor(
+    private val preferences: TodoPreferences
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val mutex = Mutex()
+
+    private var activeBacking: List<TodoItem> = emptyList()
+    private var archivedBacking: List<TodoItem> = emptyList()
+
+    private val activeState = MutableStateFlow<List<TodoItem>>(emptyList())
+    private val archivedState = MutableStateFlow<List<TodoItem>>(emptyList())
+
+    val activeTasks: StateFlow<List<TodoItem>> = activeState.asStateFlow()
+    val archivedTasks: StateFlow<List<TodoItem>> = archivedState.asStateFlow()
+
+    private val initialLoad = scope.async { refreshInternal() }
+
+    suspend fun refresh() {
+        ensureInitialized()
+        refreshInternal()
+    }
+
+    suspend fun addTask(shortText: String, fullText: String = shortText): TodoItem =
+        withContext(Dispatchers.IO) {
+            ensureInitialized()
+            mutex.withLock {
+                val sanitizedShortText = shortText.trim()
+                val sanitizedFullText = fullText.ifBlank { sanitizedShortText }
+                val sorted = activeBacking.sortedBy { it.position }.toMutableList()
+                val insertionIndex = sorted.indexOfFirst { it.isDone }.takeIf { it >= 0 } ?: sorted.size
+                val newItem = TodoItem(
+                    id = UUID.randomUUID().toString(),
+                    shortText = sanitizedShortText,
+                    fullText = sanitizedFullText,
+                    isDone = false,
+                    archivedAt = null,
+                    position = insertionIndex
+                )
+                sorted.add(insertionIndex, newItem)
+                activeBacking = sorted.withNormalizedPositions()
+                persistAndPublishLocked()
+                newItem
+            }
+        }
+
+    suspend fun markTaskDone(id: String, done: Boolean = true): TodoItem? =
+        withContext(Dispatchers.IO) {
+            ensureInitialized()
+            mutex.withLock {
+                val sorted = activeBacking.sortedBy { it.position }.toMutableList()
+                val index = sorted.indexOfFirst { it.id == id }
+                if (index == -1) {
+                    return@withLock null
+                }
+                val item = sorted.removeAt(index)
+                val updated = item.copy(isDone = done)
+                if (done) {
+                    sorted.add(updated)
+                } else {
+                    val insertionIndex = sorted.indexOfFirst { it.isDone }.takeIf { it >= 0 } ?: sorted.size
+                    sorted.add(insertionIndex, updated)
+                }
+                activeBacking = sorted.withNormalizedPositions()
+                persistAndPublishLocked()
+                updated
+            }
+        }
+
+    suspend fun toggleTask(id: String): TodoItem? = withContext(Dispatchers.IO) {
+        ensureInitialized()
+        val current = mutex.withLock {
+            activeBacking.firstOrNull { it.id == id }
+        }
+        current?.let { markTaskDone(id, !it.isDone) }
+    }
+
+    suspend fun reorder(id: String, targetIndex: Int): List<TodoItem>? =
+        withContext(Dispatchers.IO) {
+            ensureInitialized()
+            mutex.withLock {
+                val sorted = activeBacking.sortedBy { it.position }.toMutableList()
+                val totalUndone = sorted.count { !it.isDone }
+                val currentIndex = sorted.indexOfFirst { it.id == id }
+                if (currentIndex == -1) {
+                    return@withLock null
+                }
+                val item = sorted[currentIndex]
+                if (item.isDone) {
+                    return@withLock null
+                }
+                sorted.removeAt(currentIndex)
+                val newUndoneCount = totalUndone - 1
+                val destination = targetIndex.coerceIn(0, newUndoneCount)
+                sorted.add(destination, item)
+                activeBacking = sorted.withNormalizedPositions()
+                persistAndPublishLocked()
+                activeState.value
+            }
+        }
+
+    suspend fun archiveTask(id: String): TodoItem? = withContext(Dispatchers.IO) {
+        ensureInitialized()
+        mutex.withLock {
+            val sorted = activeBacking.sortedBy { it.position }.toMutableList()
+            val index = sorted.indexOfFirst { it.id == id }
+            if (index == -1) {
+                return@withLock null
+            }
+            val removed = sorted.removeAt(index)
+            val archived = removed.copy(archivedAt = System.currentTimeMillis())
+            activeBacking = sorted.withNormalizedPositions()
+            archivedBacking = (archivedBacking + archived).sortedArchived()
+            persistAndPublishLocked()
+            archived
+        }
+    }
+
+    suspend fun restoreTask(id: String): TodoItem? = withContext(Dispatchers.IO) {
+        ensureInitialized()
+        mutex.withLock {
+            val index = archivedBacking.indexOfFirst { it.id == id }
+            if (index == -1) {
+                return@withLock null
+            }
+            val archivedItem = archivedBacking[index]
+            val sortedActive = activeBacking.sortedBy { it.position }.toMutableList()
+            val insertionIndex = sortedActive.indexOfFirst { it.isDone }.takeIf { it >= 0 } ?: sortedActive.size
+            val restored = archivedItem.copy(
+                isDone = false,
+                archivedAt = null,
+                position = insertionIndex
+            )
+            archivedBacking = archivedBacking.toMutableList().also { it.removeAt(index) }.sortedArchived()
+            sortedActive.add(insertionIndex, restored)
+            activeBacking = sortedActive.withNormalizedPositions()
+            persistAndPublishLocked()
+            restored
+        }
+    }
+
+    suspend fun expandTask(id: String): TodoItem? = withContext(Dispatchers.IO) {
+        ensureInitialized()
+        mutex.withLock {
+            activeBacking.firstOrNull { it.id == id } ?: archivedBacking.firstOrNull { it.id == id }
+        }
+    }
+
+    private suspend fun refreshInternal() {
+        val snapshot = preferences.load()
+        mutex.withLock {
+            activeBacking = arrangeActive(dedupe(snapshot.active))
+            archivedBacking = dedupe(snapshot.archived).sortedArchived()
+            publishLocked()
+        }
+    }
+
+    private suspend fun persistAndPublishLocked() {
+        preferences.persist(activeBacking, archivedBacking)
+        publishLocked()
+    }
+
+    private fun publishLocked() {
+        activeState.value = activeBacking.filter { !it.isDone && it.archivedAt == null }
+        archivedState.value = archivedBacking
+    }
+
+    private fun arrangeActive(items: List<TodoItem>): List<TodoItem> {
+        if (items.isEmpty()) {
+            return emptyList()
+        }
+        val sanitized = items.map { item ->
+            if (item.archivedAt != null) item.copy(archivedAt = null) else item
+        }.sortedBy { it.position }
+        val (undone, done) = sanitized.partition { !it.isDone }
+        return (undone + done).withNormalizedPositions()
+    }
+
+    private fun List<TodoItem>.withNormalizedPositions(): List<TodoItem> =
+        mapIndexed { index, item ->
+            if (item.position != index) {
+                item.copy(position = index)
+            } else {
+                item
+            }
+        }
+
+    private fun List<TodoItem>.sortedArchived(): List<TodoItem> =
+        sortedWith(
+            compareByDescending<TodoItem> { it.archivedAt ?: Long.MIN_VALUE }
+                .thenBy { it.position }
+        )
+
+    private fun dedupe(items: List<TodoItem>): List<TodoItem> {
+        if (items.isEmpty()) return emptyList()
+        val map = LinkedHashMap<String, TodoItem>(items.size)
+        for (item in items) {
+            if (!map.containsKey(item.id)) {
+                map[item.id] = item
+            }
+        }
+        return map.values.toList()
+    }
+
+    private suspend fun ensureInitialized() {
+        if (!initialLoad.isCompleted) {
+            initialLoad.await()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a TodoItem model and encrypted shared-preferences storage for active and archived tasks
- implement a TodoRepository singleton that surfaces flows for active and archived tasks and supports add/mark/reorder/archive/restore/expand intents

## Testing
- ./gradlew :hub:assembleDebug *(fails: Android SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7795e1fc8332a581ebe084f84677