### PR TITLE
Add todo HUD view model and control panel

### DIFF
--- a/hub/src/main/java/io/texne/g1/hub/todo/TodoHudFormatter.kt
+++ b/hub/src/main/java/io/texne/g1/hub/todo/TodoHudFormatter.kt
@@ -1,0 +1,148 @@
+package io.texne.g1.hub.todo
+
+/**
+ * Formats todo items into HUD friendly pages. Each page contains exactly [LINES_PER_PAGE] lines
+ * capped at [MAX_CHARACTERS_PER_LINE] characters (respecting both the 50 character design target
+ * and the HUD's 40 character hardware limit). Summary lines are truncated with ellipsis while
+ * expanded pages leverage the repository's stored [TodoItem.fullText].
+ */
+object TodoHudFormatter {
+    const val LINES_PER_PAGE = 4
+    private const val SPEC_MAX_CHARACTERS_PER_LINE = 50
+    private const val HUD_CHARACTER_LIMIT = 40
+    private const val MAX_CHARACTERS_PER_LINE =
+        if (SPEC_MAX_CHARACTERS_PER_LINE < HUD_CHARACTER_LIMIT) SPEC_MAX_CHARACTERS_PER_LINE else HUD_CHARACTER_LIMIT
+    private const val ELLIPSIS = "..."
+    private const val DETAIL_INDENT = "   "
+    private val whitespaceRegex = Regex("""\s+""")
+
+    fun format(
+        tasks: List<TodoItem>,
+        mode: TodoDisplayMode,
+        expandedTaskId: Long? = null
+    ): List<List<String>> {
+        if (tasks.isEmpty()) {
+            return emptyList()
+        }
+
+        val numbering = tasks.mapIndexed { index, task ->
+            task.id to (index + 1)
+        }.toMap()
+
+        val lines = when {
+            mode == TodoDisplayMode.SUMMARY -> buildSummaryLines(tasks, numbering)
+            expandedTaskId != null -> {
+                val task = tasks.firstOrNull { it.id == expandedTaskId }
+                if (task != null) {
+                    buildFullLines(listOf(task), numbering)
+                } else {
+                    buildFullLines(tasks, numbering)
+                }
+            }
+            else -> buildFullLines(tasks, numbering)
+        }
+
+        return lines
+            .chunked(LINES_PER_PAGE)
+            .map { chunk -> padToPage(chunk) }
+    }
+
+    private fun buildSummaryLines(
+        tasks: List<TodoItem>,
+        numbering: Map<Long, Int>
+    ): List<String> {
+        return tasks.map { task ->
+            val index = numbering[task.id] ?: 0
+            val status = if (task.isCompleted) "[✔]" else "[ ]"
+            val raw = "$index. $status ${task.summary}".trim()
+            truncate(raw)
+        }
+    }
+
+    private fun buildFullLines(
+        tasks: List<TodoItem>,
+        numbering: Map<Long, Int>
+    ): List<String> {
+        val lines = mutableListOf<String>()
+        tasks.forEach { task ->
+            val index = numbering[task.id] ?: 0
+            val status = if (task.isCompleted) "[✔]" else "[ ]"
+            val header = "$index. $status ${task.summary}".trim()
+            lines += truncate(header)
+
+            val wrappedDetails = wrapText(task.fullText, MAX_CHARACTERS_PER_LINE - DETAIL_INDENT.length)
+            wrappedDetails.forEach { detail ->
+                lines += truncate(DETAIL_INDENT + detail)
+            }
+        }
+        return lines
+    }
+
+    private fun padToPage(lines: List<String>): List<String> {
+        val padded = lines.toMutableList()
+        while (padded.size < LINES_PER_PAGE) {
+            padded += ""
+        }
+        return padded.take(LINES_PER_PAGE)
+    }
+
+    private fun truncate(text: String): String {
+        if (text.length <= MAX_CHARACTERS_PER_LINE) {
+            return text
+        }
+        if (MAX_CHARACTERS_PER_LINE <= ELLIPSIS.length) {
+            return ELLIPSIS.take(MAX_CHARACTERS_PER_LINE)
+        }
+        return text.take(MAX_CHARACTERS_PER_LINE - ELLIPSIS.length) + ELLIPSIS
+    }
+
+    private fun wrapText(text: String, maxChars: Int): List<String> {
+        if (text.isBlank()) {
+            return emptyList()
+        }
+
+        val normalized = text
+            .replace('\n', ' ')
+            .replace(whitespaceRegex, " ")
+            .trim()
+
+        if (normalized.isEmpty()) {
+            return emptyList()
+        }
+
+        val lines = mutableListOf<String>()
+        var currentLine = StringBuilder()
+
+        fun flush() {
+            if (currentLine.isNotEmpty()) {
+                lines += currentLine.toString()
+                currentLine = StringBuilder()
+            }
+        }
+
+        normalized.split(" ").forEach { rawWord ->
+            if (rawWord.isEmpty()) return@forEach
+
+            var word = rawWord
+            while (word.length > maxChars) {
+                if (currentLine.isNotEmpty()) {
+                    flush()
+                }
+                lines += word.take(maxChars)
+                word = word.drop(maxChars)
+            }
+
+            val candidate = if (currentLine.isEmpty()) word else "${currentLine} $word"
+            if (candidate.length <= maxChars) {
+                currentLine.clear()
+                currentLine.append(candidate)
+            } else {
+                flush()
+                currentLine.append(word)
+            }
+        }
+
+        flush()
+        return lines
+    }
+}

--- a/hub/src/main/java/io/texne/g1/hub/todo/TodoHudFormatter.kt
+++ b/hub/src/main/java/io/texne/g1/hub/todo/TodoHudFormatter.kt
@@ -10,8 +10,8 @@ object TodoHudFormatter {
     const val LINES_PER_PAGE = 4
     private const val SPEC_MAX_CHARACTERS_PER_LINE = 50
     private const val HUD_CHARACTER_LIMIT = 40
-    private const val MAX_CHARACTERS_PER_LINE =
-        if (SPEC_MAX_CHARACTERS_PER_LINE < HUD_CHARACTER_LIMIT) SPEC_MAX_CHARACTERS_PER_LINE else HUD_CHARACTER_LIMIT
+    private val MAX_CHARACTERS_PER_LINE =
+        minOf(SPEC_MAX_CHARACTERS_PER_LINE, HUD_CHARACTER_LIMIT)
     private const val ELLIPSIS = "..."
     private const val DETAIL_INDENT = "   "
     private val whitespaceRegex = Regex("""\s+""")

--- a/hub/src/main/java/io/texne/g1/hub/todo/TodoModels.kt
+++ b/hub/src/main/java/io/texne/g1/hub/todo/TodoModels.kt
@@ -1,0 +1,19 @@
+package io.texne.g1.hub.todo
+
+/**
+ * Represents a single todo entry managed by the HUD todo experience.
+ */
+data class TodoItem(
+    val id: Long,
+    val summary: String,
+    val fullText: String,
+    val isCompleted: Boolean = false
+)
+
+/**
+ * Modes that determine how todos are formatted for the HUD.
+ */
+enum class TodoDisplayMode {
+    SUMMARY,
+    FULL
+}

--- a/hub/src/main/java/io/texne/g1/hub/todo/TodoRepository.kt
+++ b/hub/src/main/java/io/texne/g1/hub/todo/TodoRepository.kt
@@ -1,0 +1,103 @@
+package io.texne.g1.hub.todo
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import io.texne.g1.hub.model.Repository
+
+@Singleton
+class TodoRepository @Inject constructor(
+    private val serviceRepository: Repository
+) {
+    private val itemsFlow = MutableStateFlow<List<TodoItem>>(emptyList())
+    val items: StateFlow<List<TodoItem>> = itemsFlow.asStateFlow()
+
+    init {
+        if (itemsFlow.value.isEmpty()) {
+            itemsFlow.value = listOf(
+                TodoItem(
+                    id = 1L,
+                    summary = "Outline the onboarding walkthrough",
+                    fullText = "Draft the full onboarding walkthrough for new G1 wearers, including safety tips and quick-start instructions.",
+                ),
+                TodoItem(
+                    id = 2L,
+                    summary = "Test the BLE reconnection flow",
+                    fullText = "Verify that the background reconnection flow gracefully recovers after toggling Bluetooth and document any timing issues.",
+                ),
+                TodoItem(
+                    id = 3L,
+                    summary = "Schedule user research interviews",
+                    fullText = "Coordinate with the research team to schedule three interviews with early adopters and capture their availability windows.",
+                ),
+                TodoItem(
+                    id = 4L,
+                    summary = "Prepare demo HUD copy",
+                    fullText = "Write the long-form copy used in the live demo, including alternate states for error conditions and fallback prompts.",
+                )
+            )
+        }
+    }
+
+    fun replaceAll(newItems: List<TodoItem>) {
+        itemsFlow.value = newItems
+    }
+
+    fun toggleCompletion(id: Long) {
+        itemsFlow.update { items ->
+            items.map { item ->
+                if (item.id == id) {
+                    item.copy(isCompleted = !item.isCompleted)
+                } else {
+                    item
+                }
+            }
+        }
+    }
+
+    fun moveTaskUp(id: Long) {
+        itemsFlow.update { items ->
+            val index = items.indexOfFirst { it.id == id }
+            if (index <= 0) return@update items
+            val mutable = items.toMutableList()
+            val task = mutable.removeAt(index)
+            mutable.add(index - 1, task)
+            mutable.toList()
+        }
+    }
+
+    fun moveTaskDown(id: Long) {
+        itemsFlow.update { items ->
+            val index = items.indexOfFirst { it.id == id }
+            if (index == -1 || index >= items.lastIndex) return@update items
+            val mutable = items.toMutableList()
+            val task = mutable.removeAt(index)
+            mutable.add(index + 1, task)
+            mutable.toList()
+        }
+    }
+
+    suspend fun displayHudPage(lines: List<String>, animate: Boolean = true): Boolean {
+        val pages = listOf(padLines(lines))
+        val holdMillis = if (animate) DEFAULT_PAGE_HOLD_MILLIS else null
+        return serviceRepository.displayCenteredOnConnectedGlasses(pages, holdMillis)
+    }
+
+    suspend fun stopHudDisplay(): Boolean =
+        serviceRepository.stopDisplayingOnConnectedGlasses()
+
+    private fun padLines(lines: List<String>): List<String> {
+        val mutable = lines.toMutableList()
+        while (mutable.size < TodoHudFormatter.LINES_PER_PAGE) {
+            mutable += ""
+        }
+        return mutable.take(TodoHudFormatter.LINES_PER_PAGE)
+    }
+
+    companion object {
+        private const val DEFAULT_PAGE_HOLD_MILLIS = 4_000L
+    }
+}

--- a/hub/src/main/java/io/texne/g1/hub/todo/TodoViewModel.kt
+++ b/hub/src/main/java/io/texne/g1/hub/todo/TodoViewModel.kt
@@ -1,0 +1,204 @@
+package io.texne.g1.hub.todo
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class TodoViewModel @Inject constructor(
+    private val repository: TodoRepository
+) : ViewModel() {
+
+    data class State(
+        val tasks: List<TodoItem> = emptyList(),
+        val displayMode: TodoDisplayMode = TodoDisplayMode.SUMMARY,
+        val currentPageIndex: Int = 0,
+        val pageCount: Int = 0,
+        val expandedTaskId: Long? = null,
+        val summaryHighlightRange: IntRange? = null
+    ) {
+        val isSummaryMode: Boolean get() = displayMode == TodoDisplayMode.SUMMARY
+        val isFullMode: Boolean get() = displayMode == TodoDisplayMode.FULL
+        val showingSingleTask: Boolean get() = isFullMode && expandedTaskId != null
+    }
+
+    private val _state = MutableStateFlow(State())
+    val state: StateFlow<State> = _state.asStateFlow()
+
+    private var cachedPages: List<List<String>> = emptyList()
+    private var hudJob: Job? = null
+
+    init {
+        viewModelScope.launch {
+            repository.items.collectLatest { items ->
+                applyChanges(tasks = items, animate = true)
+            }
+        }
+    }
+
+    fun onTaskToggle(id: Long) {
+        repository.toggleCompletion(id)
+    }
+
+    fun onMoveTaskUp(id: Long) {
+        repository.moveTaskUp(id)
+    }
+
+    fun onMoveTaskDown(id: Long) {
+        repository.moveTaskDown(id)
+    }
+
+    fun onTapHud() {
+        val state = _state.value
+        if (state.displayMode != TodoDisplayMode.SUMMARY) {
+            onDisplayModeSelected(TodoDisplayMode.SUMMARY)
+            return
+        }
+        val range = state.summaryHighlightRange ?: return
+        val targetIndex = range.first
+        val task = state.tasks.getOrNull(targetIndex) ?: return
+        repository.toggleCompletion(task.id)
+    }
+
+    fun onSwipeNextPage() {
+        setPage(_state.value.currentPageIndex + 1)
+    }
+
+    fun onSwipePreviousPage() {
+        setPage(_state.value.currentPageIndex - 1)
+    }
+
+    fun onAiCommandNextPage() {
+        onSwipeNextPage()
+    }
+
+    fun onAiCommandExpandTask(taskNumber: Int) {
+        if (taskNumber <= 0) return
+        val index = taskNumber - 1
+        val task = _state.value.tasks.getOrNull(index) ?: return
+        applyChanges(
+            displayMode = TodoDisplayMode.FULL,
+            expandedTaskId = task.id,
+            pageIndex = 0,
+            animate = true
+        )
+    }
+
+    fun onDisplayModeSelected(mode: TodoDisplayMode) {
+        val state = _state.value
+        if (state.displayMode == mode && (mode != TodoDisplayMode.FULL || state.expandedTaskId == null)) {
+            return
+        }
+        val expandedId = if (mode == TodoDisplayMode.FULL) state.expandedTaskId else null
+        applyChanges(
+            displayMode = mode,
+            expandedTaskId = expandedId,
+            pageIndex = 0,
+            animate = true
+        )
+    }
+
+    fun onShowFullList() {
+        applyChanges(
+            displayMode = TodoDisplayMode.FULL,
+            expandedTaskId = null,
+            pageIndex = 0,
+            animate = true
+        )
+    }
+
+    fun onShowSummary() {
+        applyChanges(
+            displayMode = TodoDisplayMode.SUMMARY,
+            expandedTaskId = null,
+            pageIndex = 0,
+            animate = true
+        )
+    }
+
+    fun setPage(index: Int, animate: Boolean = true) {
+        if (cachedPages.isEmpty()) return
+        val safeIndex = index.coerceIn(0, cachedPages.lastIndex)
+        if (safeIndex == _state.value.currentPageIndex) return
+        applyChanges(pageIndex = safeIndex, animate = animate)
+    }
+
+    private fun applyChanges(
+        tasks: List<TodoItem>? = null,
+        displayMode: TodoDisplayMode? = null,
+        expandedTaskId: Long? = null,
+        pageIndex: Int? = null,
+        animate: Boolean
+    ) {
+        val current = _state.value
+        val resolvedTasks = tasks ?: current.tasks
+        val resolvedMode = displayMode ?: current.displayMode
+        val resolvedExpandedId = if (resolvedMode == TodoDisplayMode.FULL) {
+            expandedTaskId ?: current.expandedTaskId
+        } else {
+            null
+        }
+
+        val pages = TodoHudFormatter.format(resolvedTasks, resolvedMode, resolvedExpandedId)
+        cachedPages = pages
+        val newPageIndex = when {
+            pages.isEmpty() -> 0
+            pageIndex != null -> pageIndex.coerceIn(0, pages.lastIndex)
+            current.currentPageIndex > pages.lastIndex -> pages.lastIndex
+            else -> current.currentPageIndex.coerceIn(0, pages.lastIndex)
+        }
+
+        val highlightRange = computeSummaryRange(resolvedMode, resolvedTasks, newPageIndex)
+
+        _state.update {
+            it.copy(
+                tasks = resolvedTasks,
+                displayMode = resolvedMode,
+                expandedTaskId = resolvedExpandedId,
+                currentPageIndex = newPageIndex,
+                pageCount = pages.size,
+                summaryHighlightRange = highlightRange
+            )
+        }
+
+        refreshHud(pages, newPageIndex, animate)
+    }
+
+    private fun computeSummaryRange(
+        mode: TodoDisplayMode,
+        tasks: List<TodoItem>,
+        pageIndex: Int
+    ): IntRange? {
+        if (mode != TodoDisplayMode.SUMMARY || tasks.isEmpty()) {
+            return null
+        }
+        val start = pageIndex * TodoHudFormatter.LINES_PER_PAGE
+        if (start >= tasks.size) {
+            return null
+        }
+        val end = minOf(tasks.lastIndex, start + TodoHudFormatter.LINES_PER_PAGE - 1)
+        return start..end
+    }
+
+    private fun refreshHud(pages: List<List<String>>, pageIndex: Int, animate: Boolean) {
+        hudJob?.cancel()
+        if (pages.isEmpty()) {
+            hudJob = viewModelScope.launch {
+                repository.stopHudDisplay()
+            }
+            return
+        }
+        val lines = pages[pageIndex]
+        hudJob = viewModelScope.launch {
+            repository.displayHudPage(lines, animate)
+        }
+    }
+}

--- a/hub/src/main/java/io/texne/g1/hub/ui/chat/ChatScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/chat/ChatScreen.kt
@@ -1,9 +1,12 @@
 package io.texne.g1.hub.ui.chat
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -15,8 +18,12 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Send
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.icons.filled.ArrowForward
+import androidx.compose.material.icons.filled.ArrowUpward
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Send
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -38,12 +45,16 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import io.texne.g1.hub.ai.ChatPersona
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.texne.g1.hub.todo.TodoDisplayMode
+import io.texne.g1.hub.todo.TodoItem
+import io.texne.g1.hub.todo.TodoViewModel
 import kotlinx.coroutines.delay
 
 @Composable
@@ -51,43 +62,63 @@ fun ChatScreen(
     connectedGlassesName: String?,
     onNavigateToSettings: () -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: ChatViewModel = hiltViewModel()
+    chatViewModel: ChatViewModel = hiltViewModel(),
+    todoViewModel: TodoViewModel = hiltViewModel()
 ) {
-    val state by viewModel.state.collectAsStateWithLifecycle()
+    val chatState by chatViewModel.state.collectAsStateWithLifecycle()
+    val todoState by todoViewModel.state.collectAsStateWithLifecycle()
 
     ChatContent(
-        state = state,
+        chatState = chatState,
+        todoState = todoState,
         connectedGlassesName = connectedGlassesName,
-        onPersonaSelected = viewModel::onPersonaSelected,
-        onSendPrompt = viewModel::sendPrompt,
+        onPersonaSelected = chatViewModel::onPersonaSelected,
+        onSendPrompt = chatViewModel::sendPrompt,
         onNavigateToSettings = onNavigateToSettings,
-        onDismissError = viewModel::clearError,
-        onHudStatusConsumed = viewModel::clearHudStatus
+        onDismissError = chatViewModel::clearError,
+        onHudStatusConsumed = chatViewModel::clearHudStatus,
+        onTodoToggle = todoViewModel::onTaskToggle,
+        onTodoMoveUp = todoViewModel::onMoveTaskUp,
+        onTodoMoveDown = todoViewModel::onMoveTaskDown,
+        onTodoModeSelected = todoViewModel::onDisplayModeSelected,
+        onTodoShowFullList = todoViewModel::onShowFullList,
+        onTodoShowSummary = todoViewModel::onShowSummary,
+        onTodoNextPage = todoViewModel::onSwipeNextPage,
+        onTodoPreviousPage = todoViewModel::onSwipePreviousPage
     )
 }
 
 @Composable
 private fun ChatContent(
-    state: ChatViewModel.State,
+    chatState: ChatViewModel.State,
+    todoState: TodoViewModel.State,
     connectedGlassesName: String?,
     onPersonaSelected: (ChatPersona) -> Unit,
     onSendPrompt: (String) -> Unit,
     onNavigateToSettings: () -> Unit,
     onDismissError: () -> Unit,
     onHudStatusConsumed: () -> Unit,
+    onTodoToggle: (Long) -> Unit,
+    onTodoMoveUp: (Long) -> Unit,
+    onTodoMoveDown: (Long) -> Unit,
+    onTodoModeSelected: (TodoDisplayMode) -> Unit,
+    onTodoShowFullList: () -> Unit,
+    onTodoShowSummary: () -> Unit,
+    onTodoNextPage: () -> Unit,
+    onTodoPreviousPage: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     var prompt by rememberSaveable { mutableStateOf("") }
     val listState = rememberLazyListState()
 
-    LaunchedEffect(state.messages.size) {
-        if (state.messages.isNotEmpty()) {
-            listState.animateScrollToItem(state.messages.lastIndex)
+    LaunchedEffect(chatState.messages.size) {
+        if (chatState.messages.isNotEmpty()) {
+            listState.animateScrollToItem(chatState.messages.lastIndex)
         }
     }
 
-    LaunchedEffect(state.hudStatus) {
-        if (state.hudStatus is ChatViewModel.HudStatus.Displayed) {
+    LaunchedEffect(chatState.hudStatus) {
+        if (chatState.hudStatus is ChatViewModel.HudStatus.Displayed) {
             delay(3_000)
             onHudStatusConsumed()
         }
@@ -107,21 +138,21 @@ private fun ChatContent(
 
         ConnectionStatus(connectedGlassesName)
 
-        if (!state.apiKeyAvailable) {
+        if (!chatState.apiKeyAvailable) {
             ApiKeyWarningCard(onNavigateToSettings = onNavigateToSettings)
         }
 
         PersonaSelector(
-            personas = state.availablePersonas,
-            selected = state.selectedPersona,
+            personas = chatState.availablePersonas,
+            selected = chatState.selectedPersona,
             onPersonaSelected = onPersonaSelected
         )
 
-        if (state.errorMessage != null) {
-            ErrorCard(message = state.errorMessage, onDismiss = onDismissError)
+        if (chatState.errorMessage != null) {
+            ErrorCard(message = chatState.errorMessage, onDismiss = onDismissError)
         }
 
-        when (val hudStatus = state.hudStatus) {
+        when (val hudStatus = chatState.hudStatus) {
             is ChatViewModel.HudStatus.DisplayFailed -> {
                 HudStatusCard(
                     text = "Unable to display response on the HUD. Check the connection and try again.",
@@ -149,13 +180,25 @@ private fun ChatContent(
             ChatViewModel.HudStatus.Idle -> Unit
         }
 
+        TodoHudPanel(
+            state = todoState,
+            onToggle = onTodoToggle,
+            onMoveUp = onTodoMoveUp,
+            onMoveDown = onTodoMoveDown,
+            onModeSelected = onTodoModeSelected,
+            onShowFullList = onTodoShowFullList,
+            onShowSummary = onTodoShowSummary,
+            onNextPage = onTodoNextPage,
+            onPreviousPage = onTodoPreviousPage
+        )
+
         Card(
             modifier = Modifier
                 .fillMaxWidth()
                 .weight(1f),
             colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
         ) {
-            if (state.isSending) {
+            if (chatState.isSending) {
                 LoadingIndicator()
             }
             LazyColumn(
@@ -165,7 +208,7 @@ private fun ChatContent(
                     .padding(12.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                if (state.messages.isEmpty()) {
+                if (chatState.messages.isEmpty()) {
                     item {
                         Text(
                             text = "Ask anything to get started.",
@@ -174,7 +217,7 @@ private fun ChatContent(
                         )
                     }
                 } else {
-                    items(state.messages, key = { it.id }) { message ->
+                    items(chatState.messages, key = { it.id }) { message ->
                         MessageBubble(message = message)
                     }
                 }
@@ -193,9 +236,9 @@ private fun ChatContent(
                 label = { Text("Ask the assistant") },
                 maxLines = 3,
                 supportingText = {
-                    if (state.selectedPersona.description.isNotEmpty()) {
+                    if (chatState.selectedPersona.description.isNotEmpty()) {
                         Text(
-                            text = state.selectedPersona.description,
+                            text = chatState.selectedPersona.description,
                             style = MaterialTheme.typography.bodySmall,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis
@@ -204,7 +247,7 @@ private fun ChatContent(
                 }
             )
 
-            val sendEnabled = prompt.isNotBlank() && state.apiKeyAvailable && !state.isSending
+            val sendEnabled = prompt.isNotBlank() && chatState.apiKeyAvailable && !chatState.isSending
             IconButton(
                 onClick = {
                     if (sendEnabled) {
@@ -216,6 +259,196 @@ private fun ChatContent(
             ) {
                 Icon(imageVector = Icons.Default.Send, contentDescription = "Send prompt")
             }
+        }
+    }
+}
+
+@Composable
+private fun TodoHudPanel(
+    state: TodoViewModel.State,
+    onToggle: (Long) -> Unit,
+    onMoveUp: (Long) -> Unit,
+    onMoveDown: (Long) -> Unit,
+    onModeSelected: (TodoDisplayMode) -> Unit,
+    onShowFullList: () -> Unit,
+    onShowSummary: () -> Unit,
+    onNextPage: () -> Unit,
+    onPreviousPage: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(
+                text = "Todo HUD",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold
+            )
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                FilterChip(
+                    selected = state.isSummaryMode,
+                    onClick = onShowSummary,
+                    label = { Text("Summary") },
+                    leadingIcon = if (state.isSummaryMode) {
+                        { Icon(imageVector = Icons.Default.Check, contentDescription = null, modifier = Modifier.size(16.dp)) }
+                    } else null,
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                        selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                        selectedLeadingIconColor = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                )
+
+                FilterChip(
+                    selected = state.isFullMode,
+                    onClick = { onModeSelected(TodoDisplayMode.FULL) },
+                    label = { Text("Full text") },
+                    leadingIcon = if (state.isFullMode) {
+                        { Icon(imageVector = Icons.Default.Check, contentDescription = null, modifier = Modifier.size(16.dp)) }
+                    } else null,
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                        selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                        selectedLeadingIconColor = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                )
+
+                if (state.showingSingleTask) {
+                    TextButton(onClick = onShowFullList) {
+                        Text("Show all tasks")
+                    }
+                }
+            }
+
+            if (state.showingSingleTask) {
+                val taskNumber = state.tasks.indexOfFirst { it.id == state.expandedTaskId } + 1
+                if (taskNumber > 0) {
+                    Text(
+                        text = "Showing full text for task #$taskNumber",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            val pageCount = state.pageCount
+            val pageIndicator = if (pageCount == 0) {
+                "Page --"
+            } else {
+                "Page ${state.currentPageIndex + 1} / $pageCount"
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(
+                    onClick = onPreviousPage,
+                    enabled = pageCount > 0 && state.currentPageIndex > 0
+                ) {
+                    Icon(imageVector = Icons.Default.ArrowBack, contentDescription = "Previous HUD page")
+                }
+                Text(text = pageIndicator, style = MaterialTheme.typography.bodyMedium)
+                IconButton(
+                    onClick = onNextPage,
+                    enabled = pageCount > 0 && state.currentPageIndex < pageCount - 1
+                ) {
+                    Icon(imageVector = Icons.Default.ArrowForward, contentDescription = "Next HUD page")
+                }
+            }
+
+            if (state.tasks.isEmpty()) {
+                Text(
+                    text = "No todo items yet.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            } else {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    state.tasks.forEachIndexed { index, item ->
+                        val highlighted = state.summaryHighlightRange?.contains(index) == true
+                        TodoRow(
+                            index = index,
+                            item = item,
+                            highlighted = highlighted,
+                            canMoveUp = index > 0,
+                            canMoveDown = index < state.tasks.lastIndex,
+                            onToggle = onToggle,
+                            onMoveUp = onMoveUp,
+                            onMoveDown = onMoveDown
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TodoRow(
+    index: Int,
+    item: TodoItem,
+    highlighted: Boolean,
+    canMoveUp: Boolean,
+    canMoveDown: Boolean,
+    onToggle: (Long) -> Unit,
+    onMoveUp: (Long) -> Unit,
+    onMoveDown: (Long) -> Unit
+) {
+    val backgroundColor = if (highlighted) {
+        MaterialTheme.colorScheme.secondaryContainer
+    } else {
+        MaterialTheme.colorScheme.surface
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(MaterialTheme.shapes.medium)
+            .background(backgroundColor)
+            .clickable { onToggle(item.id) }
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(
+            text = "${index + 1}.",
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.SemiBold
+        )
+        Text(
+            text = if (item.isCompleted) "[✔]" else "[ ]",
+            style = MaterialTheme.typography.bodyMedium
+        )
+        Text(
+            text = item.summary,
+            modifier = Modifier.weight(1f),
+            style = MaterialTheme.typography.bodyMedium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        IconButton(
+            onClick = { onMoveUp(item.id) },
+            enabled = canMoveUp
+        ) {
+            Icon(imageVector = Icons.Default.ArrowUpward, contentDescription = "Move task up")
+        }
+        IconButton(
+            onClick = { onMoveDown(item.id) },
+            enabled = canMoveDown
+        ) {
+            Icon(imageVector = Icons.Default.ArrowDownward, contentDescription = "Move task down")
         }
     }
 }


### PR DESCRIPTION
## Summary
- add todo data models, repository, view model, and formatter to drive HUD pages and animation
- integrate a todo HUD control card in the chat screen with display mode toggles, page navigation, and reordering controls
- seed the todo repository with sample items and relay HUD refresh requests through the service repository

## Testing
- ./gradlew :hub:lint *(fails: requires local Android SDK path)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7793f7e883329bfc3a456b9142c9