### PR TITLE
Support interactive HUD page navigation for todos

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,8 @@ materialIcons = "1.7.7"
 securityCrypto = "1.1.0-alpha06"
 okhttp = "4.12.0"
 lifecycleRuntimeCompose = "2.8.7"
+junit = "4.13.2"
+mockk = "1.13.13"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -48,6 +50,9 @@ androidx-security-crypto = { group = "androidx.security", name = "security-crypt
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntimeCompose" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/hub/build.gradle.kts
+++ b/hub/build.gradle.kts
@@ -69,4 +69,8 @@ dependencies {
     implementation(libs.okhttp.logging)
 
     kapt(libs.hilt.android.compiler)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/hub/src/main/java/io/texne/g1/hub/ai/ChatPersona.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ai/ChatPersona.kt
@@ -7,7 +7,7 @@ data class ChatPersona(
     val systemPrompt: String,
     val temperature: Double = 0.7,
     val maxTokens: Int = 220,
-    val hudHoldMillis: Long = 5_000L
+    val hudHoldMillis: Long? = 5_000L
 )
 
 object ChatPersonas {

--- a/hub/src/main/java/io/texne/g1/hub/model/Repository.kt
+++ b/hub/src/main/java/io/texne/g1/hub/model/Repository.kt
@@ -48,32 +48,42 @@ class Repository @Inject constructor(
             return false
         }
         val connected = service.listConnectedGlasses().firstOrNull() ?: return false
-        if (pages.isEmpty()) {
+        val sanitizedPages = sanitizePages(pages)
+        if (sanitizedPages.isEmpty()) {
             return false
         }
 
-        val sanitizedPages = pages.map { it.take(MAX_LINES_PER_PAGE) }
-
-        return if (sanitizedPages.size == 1) {
-            service.displayCentered(connected.id, sanitizedPages.first(), holdMillis)
-        } else {
-            val duration = holdMillis ?: DEFAULT_PAGE_HOLD_MILLIS
-            val sequence = sanitizedPages.map { lines ->
-                G1ServiceCommon.TimedFormattedPage(
-                    page = G1ServiceCommon.FormattedPage(
-                        justify = G1ServiceCommon.JustifyPage.CENTER,
-                        lines = lines.map { line ->
-                            G1ServiceCommon.FormattedLine(
-                                text = line,
-                                justify = G1ServiceCommon.JustifyLine.CENTER
-                            )
-                        }
-                    ),
-                    milliseconds = duration
-                )
+        return when {
+            sanitizedPages.size == 1 ->
+                service.displayCentered(connected.id, sanitizedPages.first(), holdMillis)
+            holdMillis == null ->
+                displayCenteredPage(connected.id, sanitizedPages, 0)
+            else -> {
+                val duration = holdMillis ?: DEFAULT_PAGE_HOLD_MILLIS
+                val sequence = sanitizedPages.map { lines ->
+                    G1ServiceCommon.TimedFormattedPage(
+                        page = buildCenteredFormattedPage(lines),
+                        milliseconds = duration
+                    )
+                }
+                service.displayFormattedPageSequence(connected.id, sequence)
             }
-            service.displayFormattedPageSequence(connected.id, sequence)
         }
+    }
+
+    suspend fun displayCenteredPageOnConnectedGlasses(
+        pages: List<List<String>>,
+        pageIndex: Int
+    ): Boolean {
+        if(!::service.isInitialized) {
+            return false
+        }
+        val connected = service.listConnectedGlasses().firstOrNull() ?: return false
+        val sanitizedPages = sanitizePages(pages)
+        if (sanitizedPages.isEmpty() || pageIndex !in sanitizedPages.indices) {
+            return false
+        }
+        return displayCenteredPage(connected.id, sanitizedPages, pageIndex)
     }
 
     suspend fun stopDisplayingOnConnectedGlasses(): Boolean {
@@ -84,10 +94,37 @@ class Repository @Inject constructor(
         return service.stopDisplaying(connected.id)
     }
 
+    internal fun setServiceManagerForTest(serviceManager: G1ServiceManager) {
+        service = serviceManager
+    }
+
     private lateinit var service: G1ServiceManager
 
     private companion object {
         private const val DEFAULT_PAGE_HOLD_MILLIS = 4_000L
         private const val MAX_LINES_PER_PAGE = 4
     }
+
+    private fun sanitizePages(pages: List<List<String>>): List<List<String>> =
+        pages.map { it.take(MAX_LINES_PER_PAGE) }.filter { it.isNotEmpty() }
+
+    private suspend fun displayCenteredPage(
+        glassesId: String,
+        pages: List<List<String>>,
+        pageIndex: Int
+    ): Boolean {
+        val pageLines = pages[pageIndex]
+        return service.displayFormattedPage(glassesId, buildCenteredFormattedPage(pageLines))
+    }
+
+    private fun buildCenteredFormattedPage(lines: List<String>): G1ServiceCommon.FormattedPage =
+        G1ServiceCommon.FormattedPage(
+            justify = G1ServiceCommon.JustifyPage.CENTER,
+            lines = lines.map { line ->
+                G1ServiceCommon.FormattedLine(
+                    text = line,
+                    justify = G1ServiceCommon.JustifyLine.CENTER
+                )
+            }
+        )
 }

--- a/hub/src/test/java/io/texne/g1/hub/MainDispatcherRule.kt
+++ b/hub/src/test/java/io/texne/g1/hub/MainDispatcherRule.kt
@@ -1,0 +1,23 @@
+package io.texne.g1.hub
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    private val dispatcher: TestDispatcher = StandardTestDispatcher()
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/hub/src/test/java/io/texne/g1/hub/model/RepositoryTest.kt
+++ b/hub/src/test/java/io/texne/g1/hub/model/RepositoryTest.kt
@@ -1,0 +1,101 @@
+package io.texne.g1.hub.model
+
+import android.content.Context
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.slot
+import io.texne.g1.basis.client.G1ServiceCommon
+import io.texne.g1.basis.client.G1ServiceManager
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class RepositoryTest {
+
+    @MockK(relaxed = true)
+    lateinit var context: Context
+
+    @MockK(relaxed = true)
+    lateinit var service: G1ServiceManager
+
+    private lateinit var repository: Repository
+
+    private val connectedGlasses = G1ServiceCommon.Glasses(
+        id = "glasses-id",
+        name = "Glasses",
+        status = G1ServiceCommon.GlassesStatus.CONNECTED,
+        batteryPercentage = 90
+    )
+
+    @BeforeTest
+    fun setUp() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        every { service.listConnectedGlasses() } returns listOf(connectedGlasses)
+        repository = Repository(context)
+        repository.setServiceManagerForTest(service)
+    }
+
+    @Test
+    fun `interactive pages display first page without timed sequence`() = runTest {
+        val pages = listOf(
+            listOf("Task 1", "Task 2"),
+            listOf("Task 3")
+        )
+        val formattedPage = slot<G1ServiceCommon.FormattedPage>()
+        coEvery { service.displayFormattedPage(connectedGlasses.id, capture(formattedPage)) } returns true
+
+        val result = repository.displayCenteredOnConnectedGlasses(pages, holdMillis = null)
+
+        assertTrue(result)
+        coVerify(exactly = 1) { service.displayFormattedPage(connectedGlasses.id, any()) }
+        coVerify(exactly = 0) { service.displayFormattedPageSequence(any(), any()) }
+        assertEquals(pages.first(), formattedPage.captured.lines.map { it.text })
+    }
+
+    @Test
+    fun `multi-page responses with hold still schedule timed sequence`() = runTest {
+        val pages = listOf(listOf("Task 1"), listOf("Task 2"))
+        val sequenceSlot = slot<List<G1ServiceCommon.TimedFormattedPage>>()
+        coEvery { service.displayFormattedPageSequence(connectedGlasses.id, capture(sequenceSlot)) } returns true
+
+        val result = repository.displayCenteredOnConnectedGlasses(pages, holdMillis = 2_500L)
+
+        assertTrue(result)
+        coVerify(exactly = 1) { service.displayFormattedPageSequence(connectedGlasses.id, any()) }
+        coVerify(exactly = 0) { service.displayFormattedPage(connectedGlasses.id, any()) }
+        assertEquals(2, sequenceSlot.captured.size)
+        assertTrue(sequenceSlot.captured.all { it.milliseconds == 2_500L })
+    }
+
+    @Test
+    fun `displayCenteredPageOnConnectedGlasses shows requested page`() = runTest {
+        val pages = listOf(
+            listOf("Task 1"),
+            listOf("Task 2", "Task 3", "Task 4", "Task 5", "Task 6")
+        )
+        val formattedPage = slot<G1ServiceCommon.FormattedPage>()
+        coEvery { service.displayFormattedPage(connectedGlasses.id, capture(formattedPage)) } returns true
+
+        val result = repository.displayCenteredPageOnConnectedGlasses(pages, pageIndex = 1)
+
+        assertTrue(result)
+        coVerify(exactly = 1) { service.displayFormattedPage(connectedGlasses.id, any()) }
+        assertEquals(listOf("Task 2", "Task 3", "Task 4", "Task 5"), formattedPage.captured.lines.map { it.text })
+    }
+
+    @Test
+    fun `displayCenteredPageOnConnectedGlasses returns false for invalid index`() = runTest {
+        val pages = listOf(listOf("Task 1"), listOf("Task 2"))
+
+        val result = repository.displayCenteredPageOnConnectedGlasses(pages, pageIndex = 5)
+
+        assertFalse(result)
+        coVerify(exactly = 0) { service.displayFormattedPage(any(), any()) }
+    }
+}

--- a/hub/src/test/java/io/texne/g1/hub/ui/chat/ChatViewModelTest.kt
+++ b/hub/src/test/java/io/texne/g1/hub/ui/chat/ChatViewModelTest.kt
@@ -1,0 +1,75 @@
+package io.texne.g1.hub.ui.chat
+
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.texne.g1.hub.MainDispatcherRule
+import io.texne.g1.hub.ai.ChatGptRepository
+import io.texne.g1.hub.ai.ChatPersona
+import io.texne.g1.hub.model.Repository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class ChatViewModelTest {
+
+    @get:Rule
+    val dispatcherRule = MainDispatcherRule()
+
+    @MockK(relaxed = true)
+    lateinit var chatRepository: ChatGptRepository
+
+    @MockK(relaxed = true)
+    lateinit var serviceRepository: Repository
+
+    private val apiKeyFlow = MutableStateFlow<String?>("test-key")
+
+    @BeforeTest
+    fun setUp() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        every { chatRepository.observeApiKey() } returns apiKeyFlow
+    }
+
+    @Test
+    fun `hud page requests trigger repository when interactive pages available`() = runTest {
+        val viewModel = ChatViewModel(chatRepository, serviceRepository)
+        val persona = ChatPersona(
+            id = "todo",
+            displayName = "Todo",
+            description = "",
+            systemPrompt = "",
+            hudHoldMillis = null
+        )
+        viewModel.onPersonaSelected(persona)
+
+        val response = "Item one. Item two. Item three. Item four. Item five. Item six."
+        coEvery { chatRepository.requestChatCompletion(persona, any()) } returns Result.success(response)
+        coEvery { serviceRepository.displayCenteredOnConnectedGlasses(any(), any()) } returns true
+        coEvery { serviceRepository.displayCenteredPageOnConnectedGlasses(any(), any()) } returns true
+
+        viewModel.sendPrompt("show my todo list")
+        advanceUntilIdle()
+
+        viewModel.onHudPageRequested(1)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            serviceRepository.displayCenteredPageOnConnectedGlasses(match { it.size > 1 }, 1)
+        }
+    }
+
+    @Test
+    fun `hud page requests ignored when no pages cached`() = runTest {
+        val viewModel = ChatViewModel(chatRepository, serviceRepository)
+
+        viewModel.onHudPageRequested(0)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { serviceRepository.displayCenteredPageOnConnectedGlasses(any(), any()) }
+    }
+}


### PR DESCRIPTION
## Summary
- refactor the hub repository so multi-page payloads can either run as timed sequences or stay on a specific page, and expose a helper to render an arbitrary page immediately
- update the chat view model to retain interactive HUD pages and honor gesture/app page-change requests through the new repository API
- add unit tests and supporting dependencies that confirm interactive pages avoid timed sequences and only change when explicitly requested

## Testing
- `./gradlew :hub:test` *(fails: Android SDK not configured in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd77831cac8332b5a16dff004f8a84