### PR TITLE
Add HUD-aware todo management UI and formatter

### DIFF
--- a/hub/src/main/java/io/texne/g1/hub/todo/TodoHudFormatter.kt
+++ b/hub/src/main/java/io/texne/g1/hub/todo/TodoHudFormatter.kt
@@ -1,0 +1,151 @@
+package io.texne.g1.hub.todo
+
+import kotlin.math.min
+
+object TodoHudFormatter {
+    const val HUD_CHECKED_ICON = "[✔]"
+    const val HUD_UNCHECKED_ICON = "[ ]"
+    const val MAX_ITEMS_PER_PAGE = 4
+    const val MAX_CHAR_PER_LINE = 50
+    private const val TITLE = "TODO"
+    private const val EMPTY_MESSAGE = "All caught up!"
+    private const val ELLIPSIS = "..."
+    private val whitespaceRegex = Regex("""\s+""")
+
+    data class Result(
+        val pages: List<List<String>>
+    )
+
+    enum class DisplayMode { SUMMARY, FULL }
+
+    fun format(
+        tasks: List<TodoItem>,
+        displayMode: DisplayMode,
+        expandedTaskId: String?
+    ): Result {
+        if (expandedTaskId != null) {
+            val expandedIndex = tasks.indexOfFirst { it.id == expandedTaskId }
+            if (expandedIndex != -1) {
+                return Result(pages = formatExpanded(tasks[expandedIndex], expandedIndex))
+            }
+        }
+
+        val lines = if (tasks.isEmpty()) {
+            listOf(TITLE, EMPTY_MESSAGE)
+        } else {
+            tasks.mapIndexed { index, item ->
+                val content = when (displayMode) {
+                    DisplayMode.SUMMARY -> item.shortText
+                    DisplayMode.FULL -> item.fullText
+                }
+                buildListLine(index + 1, item.isDone, content)
+            }
+        }
+
+        val pages = lines.chunked(MAX_ITEMS_PER_PAGE).ifEmpty {
+            listOf(listOf(TITLE, EMPTY_MESSAGE))
+        }
+
+        return Result(pages = pages)
+    }
+
+    private fun formatExpanded(
+        item: TodoItem,
+        index: Int
+    ): List<List<String>> {
+        val header = buildListLine(index + 1, item.isDone, item.shortText)
+        val body = wrapFullText(item.fullText)
+        if (body.isEmpty()) {
+            return listOf(listOf(header))
+        }
+
+        val pages = mutableListOf<List<String>>()
+        var cursor = 0
+        while (cursor < body.size) {
+            val chunkEnd = min(cursor + (MAX_ITEMS_PER_PAGE - 1), body.size)
+            val chunk = body.subList(cursor, chunkEnd)
+            pages += listOf(header) + chunk
+            cursor += MAX_ITEMS_PER_PAGE - 1
+        }
+
+        return pages
+    }
+
+    private fun buildListLine(index: Int, isDone: Boolean, rawText: String): String {
+        val base = sanitize(rawText)
+        val icon = if (isDone) HUD_CHECKED_ICON else HUD_UNCHECKED_ICON
+        val composed = "$index. $icon $base"
+        return trimToLimit(composed)
+    }
+
+    private fun sanitize(text: String): String {
+        if (text.isBlank()) {
+            return ""
+        }
+        return text
+            .replace('\n', ' ')
+            .replace(whitespaceRegex, " ")
+            .trim()
+    }
+
+    private fun wrapFullText(text: String): List<String> {
+        val normalized = sanitize(text)
+        if (normalized.isEmpty()) {
+            return emptyList()
+        }
+
+        val lines = mutableListOf<String>()
+        var current = StringBuilder()
+
+        fun flushCurrent() {
+            if (current.isNotEmpty()) {
+                lines += current.toString()
+                current = StringBuilder()
+            }
+        }
+
+        normalized.split(' ').forEach { word ->
+            if (word.isEmpty()) return@forEach
+            if (word.length > MAX_CHAR_PER_LINE) {
+                flushCurrent()
+                lines += chunkLongWord(word)
+                return@forEach
+            }
+
+            val candidate = if (current.isEmpty()) word else "${current} $word"
+            if (candidate.length <= MAX_CHAR_PER_LINE) {
+                current.clear()
+                current.append(candidate)
+            } else {
+                flushCurrent()
+                current.append(word)
+            }
+        }
+
+        flushCurrent()
+
+        return lines
+    }
+
+    private fun chunkLongWord(word: String): List<String> {
+        val chunks = mutableListOf<String>()
+        var start = 0
+        while (start < word.length) {
+            val end = min(start + MAX_CHAR_PER_LINE, word.length)
+            chunks += word.substring(start, end)
+            start = end
+        }
+        return chunks
+    }
+
+    private fun trimToLimit(text: String): String {
+        if (text.length <= MAX_CHAR_PER_LINE) {
+            return text
+        }
+        val limit = MAX_CHAR_PER_LINE - ELLIPSIS.length
+        if (limit <= 0) {
+            return ELLIPSIS.take(MAX_CHAR_PER_LINE)
+        }
+        return text.take(limit) + ELLIPSIS
+    }
+}

--- a/hub/src/main/java/io/texne/g1/hub/todo/TodoRepository.kt
+++ b/hub/src/main/java/io/texne/g1/hub/todo/TodoRepository.kt
@@ -178,7 +178,7 @@ class TodoRepository @Inject constructor(
     }
 
     private fun publishLocked() {
-        activeState.value = activeBacking.filter { !it.isDone && it.archivedAt == null }
+        activeState.value = activeBacking.filter { it.archivedAt == null }
         archivedState.value = archivedBacking
     }
 

--- a/hub/src/main/java/io/texne/g1/hub/ui/todo/TodoViewModel.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/todo/TodoViewModel.kt
@@ -1,0 +1,210 @@
+package io.texne.g1.hub.ui.todo
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.texne.g1.hub.model.Repository
+import io.texne.g1.hub.todo.TodoHudFormatter
+import io.texne.g1.hub.todo.TodoHudFormatter.DisplayMode
+import io.texne.g1.hub.todo.TodoItem
+import io.texne.g1.hub.todo.TodoRepository
+import javax.inject.Inject
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class TodoViewModel @Inject constructor(
+    private val todoRepository: TodoRepository,
+    private val serviceRepository: Repository
+) : ViewModel() {
+
+    data class State(
+        val tasks: List<TodoItem> = emptyList(),
+        val displayMode: DisplayMode = DisplayMode.SUMMARY,
+        val expandedTaskId: String? = null,
+        val pageIndex: Int = 0,
+        val pageCount: Int = 1,
+        val hudError: Boolean = false
+    )
+
+    sealed interface AiCommand {
+        data object NextPage : AiCommand
+        data class ExpandTask(val position: Int) : AiCommand
+    }
+
+    private val _state = MutableStateFlow(State())
+    val state: StateFlow<State> = _state.asStateFlow()
+
+    private var hudPages: List<List<String>> = emptyList()
+    private var pendingRefresh: Job? = null
+
+    init {
+        viewModelScope.launch {
+            todoRepository.refresh()
+            todoRepository.activeTasks.collectLatest { items ->
+                val ordered = items.sortedBy { it.position }
+                val sanitizedExpanded = _state.value.expandedTaskId?.takeIf { id ->
+                    ordered.any { it.id == id }
+                }
+                _state.update { state ->
+                    state.copy(
+                        tasks = ordered,
+                        expandedTaskId = sanitizedExpanded
+                    )
+                }
+                rebuildHudPages(resetIndex = true)
+            }
+        }
+    }
+
+    fun toggleTask(id: String) {
+        viewModelScope.launch { todoRepository.toggleTask(id) }
+    }
+
+    fun moveTaskUp(id: String) {
+        viewModelScope.launch {
+            val undone = _state.value.tasks.filter { !it.isDone }
+            val index = undone.indexOfFirst { it.id == id }
+            if (index > 0) {
+                todoRepository.reorder(id, index - 1)
+            }
+        }
+    }
+
+    fun moveTaskDown(id: String) {
+        viewModelScope.launch {
+            val undone = _state.value.tasks.filter { !it.isDone }
+            val index = undone.indexOfFirst { it.id == id }
+            if (index != -1 && index < undone.lastIndex) {
+                todoRepository.reorder(id, index + 1)
+            }
+        }
+    }
+
+    fun setDisplayMode(mode: DisplayMode) {
+        if (mode == _state.value.displayMode) {
+            return
+        }
+        _state.update { it.copy(displayMode = mode, expandedTaskId = null) }
+        rebuildHudPages(resetIndex = true)
+    }
+
+    fun expandTask(position: Int) {
+        val zeroBased = position - 1
+        val target = _state.value.tasks.getOrNull(zeroBased) ?: return
+        if (_state.value.expandedTaskId == target.id) {
+            return
+        }
+        _state.update { it.copy(expandedTaskId = target.id) }
+        rebuildHudPages(resetIndex = true)
+    }
+
+    fun collapseExpanded() {
+        if (_state.value.expandedTaskId == null) {
+            return
+        }
+        _state.update { it.copy(expandedTaskId = null) }
+        rebuildHudPages(resetIndex = true)
+    }
+
+    fun goToNextPage() {
+        val current = _state.value
+        val lastIndex = current.pageCount - 1
+        if (current.pageIndex >= lastIndex) {
+            return
+        }
+        updatePageIndex(current.pageIndex + 1)
+    }
+
+    fun goToPreviousPage() {
+        val current = _state.value
+        if (current.pageIndex <= 0) {
+            return
+        }
+        updatePageIndex(current.pageIndex - 1)
+    }
+
+    fun handleAiCommand(command: AiCommand) {
+        when (command) {
+            AiCommand.NextPage -> goToNextPage()
+            is AiCommand.ExpandTask -> expandTask(command.position)
+        }
+    }
+
+    fun clearHudError() {
+        if (_state.value.hudError) {
+            _state.update { it.copy(hudError = false) }
+        }
+    }
+
+    private fun rebuildHudPages(resetIndex: Boolean) {
+        val current = _state.value
+        val result = TodoHudFormatter.format(
+            tasks = current.tasks,
+            displayMode = current.displayMode,
+            expandedTaskId = current.expandedTaskId
+        )
+        val pages = result.pages.ifEmpty { listOf(listOf("")) }
+        val desiredIndex = if (resetIndex) 0 else current.pageIndex.coerceIn(0, pages.lastIndex)
+        val pagesChanged = pages != hudPages
+        hudPages = pages
+
+        _state.update {
+            it.copy(
+                pageIndex = desiredIndex,
+                pageCount = pages.size.coerceAtLeast(1)
+            )
+        }
+
+        pendingRefresh?.cancel()
+        pendingRefresh = viewModelScope.launch {
+            if (pagesChanged) {
+                sendPages(pages, desiredIndex)
+            } else {
+                displayPage(pages, desiredIndex)
+            }
+        }
+    }
+
+    private fun updatePageIndex(newIndex: Int) {
+        val pages = hudPages
+        if (pages.isEmpty() || newIndex !in pages.indices) {
+            return
+        }
+        _state.update { it.copy(pageIndex = newIndex) }
+        pendingRefresh?.cancel()
+        pendingRefresh = viewModelScope.launch {
+            displayPage(pages, newIndex)
+        }
+    }
+
+    private suspend fun sendPages(pages: List<List<String>>, pageIndex: Int) {
+        if (pages.isEmpty()) {
+            return
+        }
+        val success = serviceRepository.displayCenteredOnConnectedGlasses(pages, holdMillis = null)
+        val finalSuccess = if (success && pageIndex != 0 && pages.size > 1) {
+            serviceRepository.displayCenteredPageOnConnectedGlasses(pages, pageIndex)
+        } else {
+            success
+        }
+        updateHudError(!finalSuccess)
+    }
+
+    private suspend fun displayPage(pages: List<List<String>>, pageIndex: Int) {
+        if (pages.isEmpty()) {
+            return
+        }
+        val success = serviceRepository.displayCenteredPageOnConnectedGlasses(pages, pageIndex)
+        updateHudError(!success)
+    }
+
+    private fun updateHudError(failed: Boolean) {
+        _state.update { it.copy(hudError = failed) }
+    }
+}


### PR DESCRIPTION
## Summary
- add a TodoHudFormatter that trims task lines, chunks pages, and supports expanded full-text views for HUD playback
- introduce a TodoViewModel that tracks tasks, HUD pages, AI commands, and drives repository display updates
- enhance ChatScreen with a Todo HUD control panel and update the repository to publish completed items as well

## Testing
- `./gradlew hub:test` *(fails: Android SDK is not configured in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd87aec47c833288678287a4dec2bf