### PR TITLE
Refactor hub navigation with home grid and todo workflow

### DIFF
--- a/hub/src/main/java/io/texne/g1/hub/ui/ApplicationFrame.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/ApplicationFrame.kt
@@ -2,134 +2,322 @@ package io.texne.g1.hub.ui
 
 import GlassesScreen
 import ScannerScreen
-import androidx.compose.foundation.Image
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
-import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.texne.g1.hub.ui.chat.ChatScreen
+import io.texne.g1.hub.ui.home.HomeScreen
+import io.texne.g1.hub.ui.home.HubPalette
 import io.texne.g1.hub.ui.settings.SettingsScreen
+import io.texne.g1.hub.ui.todo.TodoScreen
 
 @Composable
 fun ApplicationFrame() {
     val viewModel = hiltViewModel<ApplicationViewModel>()
-    val state = viewModel.state.collectAsState().value
+    val state by viewModel.state.collectAsStateWithLifecycle()
 
-    var selectedSection by rememberSaveable { mutableStateOf(AppSection.GLASSES) }
+    var destination by rememberSaveable(stateSaver = AppDestination.saver()) {
+        mutableStateOf<AppDestination>(AppDestination.Home)
+    }
 
-    Column(
-        modifier = Modifier.fillMaxSize()
-    ) {
-        Header(
-            selectedSection = selectedSection,
-            onSectionSelected = { selectedSection = it }
+    Scaffold(
+        containerColor = HubPalette.Background,
+        topBar = {
+            HubTopAppBar(
+                destination = destination,
+                onNavigateHome = { destination = AppDestination.Home }
+            )
+        }
+    ) { innerPadding ->
+        DestinationContent(
+            destination = destination,
+            state = state,
+            onDestinationSelected = { destination = it },
+            onScan = viewModel::scan,
+            onConnect = viewModel::connect,
+            onDisconnect = viewModel::disconnect,
+            contentPadding = innerPadding
         )
+    }
+}
 
-        val connectedGlasses = state?.connectedGlasses
+@Composable
+private fun DestinationContent(
+    destination: AppDestination,
+    state: ApplicationViewModel.State?,
+    onDestinationSelected: (AppDestination) -> Unit,
+    onScan: () -> Unit,
+    onConnect: (String) -> Unit,
+    onDisconnect: (String) -> Unit,
+    contentPadding: PaddingValues,
+) {
+    val connectedGlasses = state?.connectedGlasses
 
-        when (selectedSection) {
-            AppSection.GLASSES -> {
-                if (connectedGlasses != null) {
-                    GlassesScreen(
-                        connectedGlasses,
-                        { viewModel.disconnect(connectedGlasses.id) }
-                    )
-                } else {
-                    ScannerScreen(
-                        scanning = state?.scanning == true,
-                        error = state?.error == true,
-                        nearbyGlasses = state?.nearbyGlasses,
-                        scan = { viewModel.scan() },
-                        connect = { viewModel.connect(it) },
+    when (destination) {
+        AppDestination.Home -> {
+            HomeScreen(
+                modifier = Modifier.padding(contentPadding),
+                onAssistantClick = { onDestinationSelected(AppDestination.Assistant) },
+                onSettingsClick = { onDestinationSelected(AppDestination.Settings) },
+                onSubtitlesClick = { onDestinationSelected(AppDestination.Subtitles) },
+                onTodoClick = { onDestinationSelected(AppDestination.Todo) },
+                onNavigationClick = { onDestinationSelected(AppDestination.Navigation) },
+                onEReaderClick = { onDestinationSelected(AppDestination.EReader) },
+                onNotificationsClick = { onDestinationSelected(AppDestination.Notifications) }
+            )
+        }
+
+        AppDestination.Assistant -> {
+            ChatScreen(
+                connectedGlassesName = connectedGlasses?.name,
+                onNavigateToSettings = { onDestinationSelected(AppDestination.Settings) },
+                modifier = Modifier
+                    .padding(contentPadding)
+                    .background(HubPalette.Background)
+            )
+        }
+
+        AppDestination.Settings -> {
+            SettingsDestination(
+                modifier = Modifier.padding(contentPadding),
+                state = state,
+                onScan = onScan,
+                onConnect = onConnect,
+                onDisconnect = onDisconnect
+            )
+        }
+
+        AppDestination.Subtitles -> {
+            SubtitlesDestination(
+                modifier = Modifier.padding(contentPadding)
+            )
+        }
+
+        AppDestination.Todo -> {
+            TodoScreen(
+                modifier = Modifier
+                    .padding(contentPadding)
+                    .background(HubPalette.Background)
+            )
+        }
+
+        AppDestination.Navigation -> {
+            ComingSoonScreen(
+                modifier = Modifier.padding(contentPadding),
+                title = "Navigation"
+            )
+        }
+
+        AppDestination.EReader -> {
+            ComingSoonScreen(
+                modifier = Modifier.padding(contentPadding),
+                title = "E-Reader"
+            )
+        }
+
+        AppDestination.Notifications -> {
+            ComingSoonScreen(
+                modifier = Modifier.padding(contentPadding),
+                title = "Notifications"
+            )
+        }
+    }
+}
+
+@Composable
+private fun HubTopAppBar(
+    destination: AppDestination,
+    onNavigateHome: () -> Unit,
+) {
+    TopAppBar(
+        title = {
+            Text(
+                text = destination.appBarTitle,
+                fontWeight = FontWeight.Bold,
+                fontSize = 20.sp
+            )
+        },
+        navigationIcon = if (destination != AppDestination.Home) {
+            {
+                IconButton(onClick = onNavigateHome) {
+                    Icon(
+                        imageVector = Icons.Filled.ArrowBack,
+                        contentDescription = "Back"
                     )
                 }
             }
-            AppSection.ASSISTANT -> {
-                ChatScreen(
-                    connectedGlassesName = connectedGlasses?.name,
-                    onNavigateToSettings = { selectedSection = AppSection.SETTINGS }
+        } else {
+            null
+        },
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = HubPalette.TopBar,
+            titleContentColor = HubPalette.OnBackground,
+            navigationIconContentColor = HubPalette.OnBackground
+        )
+    )
+}
+
+@Composable
+private fun SettingsDestination(
+    modifier: Modifier = Modifier,
+    state: ApplicationViewModel.State?,
+    onScan: () -> Unit,
+    onConnect: (String) -> Unit,
+    onDisconnect: (String) -> Unit,
+) {
+    val connectedGlasses = state?.connectedGlasses
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(HubPalette.Background)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        if (connectedGlasses != null) {
+            GlassesScreen(
+                glasses = connectedGlasses,
+                disconnect = { onDisconnect(connectedGlasses.id) }
+            )
+        } else {
+            ScannerScreen(
+                scanning = state?.scanning == true,
+                error = state?.error == true,
+                nearbyGlasses = state?.nearbyGlasses,
+                scan = onScan,
+                connect = onConnect
+            )
+        }
+
+        SettingsScreen()
+    }
+}
+
+@Composable
+private fun SubtitlesDestination(
+    modifier: Modifier = Modifier,
+) {
+    val context = androidx.compose.ui.platform.LocalContext.current
+    var launchError by rememberSaveable { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(Unit) {
+        try {
+            val intent = Intent().setClassName(
+                context,
+                "io.texne.g1.subtitles.MainActivity"
+            ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            context.startActivity(intent)
+        } catch (error: ActivityNotFoundException) {
+            launchError = "Subtitles module not installed on this device."
+        }
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(HubPalette.Background),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = launchError ?: "Launching Subtitles…",
+                color = HubPalette.OnBackground,
+                style = MaterialTheme.typography.titleMedium
+            )
+            if (launchError == null) {
+                Text(
+                    text = "You can return here after using subtitles.",
+                    color = HubPalette.OnBackground.copy(alpha = 0.7f),
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(top = 8.dp)
                 )
-            }
-            AppSection.SETTINGS -> {
-                SettingsScreen()
             }
         }
     }
 }
 
 @Composable
-fun Header(
-    selectedSection: AppSection,
-    onSectionSelected: (AppSection) -> Unit
+private fun ComingSoonScreen(
+    modifier: Modifier = Modifier,
+    title: String,
 ) {
-    Column {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(128.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            Column(
-                horizontalAlignment = Alignment.Start,
-                verticalArrangement = Arrangement.spacedBy((-8).dp)
-            ) {
-                Row {
-                    Image(
-                        painter = painterResource(io.texne.g1.basis.service.R.mipmap.ic_service_foreground),
-                        contentDescription = "G1 Hub Logo",
-                        contentScale = ContentScale.Crop,
-                        modifier = Modifier.height(40.dp).width(32.dp)
-                    )
-                    Text(
-                        "G1",
-                        fontSize = 32.sp,
-                        fontWeight = FontWeight.Black,
-                        color = Color.Gray,
-                        fontStyle = FontStyle.Italic
-                    )
-                    Text("Hub", fontSize = 32.sp, fontWeight = FontWeight.Bold)
-                }
-                Text("A hub for Basis applications", fontSize = 11.sp)
-            }
-        }
-
-        TabRow(selectedTabIndex = selectedSection.ordinal) {
-            AppSection.entries.forEach { section ->
-                Tab(
-                    selected = section == selectedSection,
-                    onClick = { onSectionSelected(section) },
-                    text = { Text(section.label) }
-                )
-            }
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(HubPalette.Background),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = "$title coming soon",
+                color = HubPalette.OnBackground,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold
+            )
+            Text(
+                text = "We're polishing the ${title.lowercase()} experience for a future release.",
+                color = HubPalette.OnBackground.copy(alpha = 0.7f),
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(top = 8.dp)
+            )
         }
     }
 }
 
-enum class AppSection(val label: String) {
-    GLASSES("Glasses"),
-    ASSISTANT("Assistant"),
-    SETTINGS("Settings")
+sealed class AppDestination(val id: String, val appBarTitle: String) {
+    data object Home : AppDestination("home", "G1 Hub")
+    data object Assistant : AppDestination("assistant", "Assistant")
+    data object Settings : AppDestination("settings", "Settings")
+    data object Subtitles : AppDestination("subtitles", "Subtitles")
+    data object Todo : AppDestination("todo", "Todo")
+    data object Navigation : AppDestination("navigation", "Navigation")
+    data object EReader : AppDestination("ereader", "E-Reader")
+    data object Notifications : AppDestination("notifications", "Notifications")
+
+    companion object {
+        fun saver(): Saver<AppDestination, String> = Saver(
+            save = { it.id },
+            restore = { value ->
+                when (value) {
+                    Assistant.id -> Assistant
+                    Settings.id -> Settings
+                    Subtitles.id -> Subtitles
+                    Todo.id -> Todo
+                    Navigation.id -> Navigation
+                    EReader.id -> EReader
+                    Notifications.id -> Notifications
+                    else -> Home
+                }
+            }
+        )
+    }
 }

--- a/hub/src/main/java/io/texne/g1/hub/ui/home/HomeScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/home/HomeScreen.kt
@@ -1,0 +1,248 @@
+package io.texne.g1.hub.ui.home
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Chat
+import androidx.compose.material.icons.outlined.Explore
+import androidx.compose.material.icons.outlined.MenuBook
+import androidx.compose.material.icons.outlined.Notifications
+import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material.icons.outlined.Subtitles
+import androidx.compose.material.icons.outlined.TaskAlt
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+object HubPalette {
+    val Background: Color = Color(0xFF041610)
+    val Surface: Color = Color(0xFF0B261B)
+    val CardAccent: Color = Color(0xFF1F5435)
+    val Accent: Color = Color(0xFF35E384)
+    val OnBackground: Color = Color(0xFFE3F5EA)
+    val OnSurface: Color = Color(0xFFD6FFE8)
+    val TopBar: Color = Color(0xFF08301F)
+}
+
+@Composable
+fun HomeScreen(
+    modifier: Modifier = Modifier,
+    onAssistantClick: () -> Unit,
+    onSettingsClick: () -> Unit,
+    onSubtitlesClick: () -> Unit,
+    onTodoClick: () -> Unit,
+    onNavigationClick: () -> Unit,
+    onEReaderClick: () -> Unit,
+    onNotificationsClick: () -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(HubPalette.Background)
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        HubHeader()
+
+        val tiles = listOf(
+            HubTile(
+                title = "Assistant",
+                description = "Chat with GPT",
+                icon = Icons.Outlined.Chat,
+                onClick = onAssistantClick
+            ),
+            HubTile(
+                title = "Settings",
+                description = "Configure your glasses",
+                icon = Icons.Outlined.Settings,
+                onClick = onSettingsClick
+            ),
+            HubTile(
+                title = "Subtitles",
+                description = "Live captioning",
+                icon = Icons.Outlined.Subtitles,
+                onClick = onSubtitlesClick
+            ),
+            HubTile(
+                title = "Todo",
+                description = "Stay on track",
+                icon = Icons.Outlined.TaskAlt,
+                onClick = onTodoClick
+            ),
+            HubTile(
+                title = "Navigation",
+                description = "Find your way",
+                icon = Icons.Outlined.Explore,
+                onClick = onNavigationClick
+            ),
+            HubTile(
+                title = "E-Reader",
+                description = "Read with ease",
+                icon = Icons.Outlined.MenuBook,
+                onClick = onEReaderClick
+            ),
+            HubTile(
+                title = "Notifications",
+                description = "Never miss an alert",
+                icon = Icons.Outlined.Notifications,
+                onClick = onNotificationsClick
+            ),
+        )
+
+        LazyVerticalGrid(
+            modifier = Modifier.fillMaxSize(),
+            columns = GridCells.Fixed(2),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            contentPadding = PaddingValues(bottom = 24.dp)
+        ) {
+            items(tiles, key = { it.title }) { tile ->
+                HubTileCard(tile = tile)
+            }
+        }
+    }
+}
+
+@Composable
+private fun HubHeader() {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Image(
+                painter = painterResource(io.texne.g1.basis.service.R.mipmap.ic_service_foreground),
+                contentDescription = "G1 Hub logo",
+                modifier = Modifier
+                    .height(48.dp)
+                    .clip(RoundedCornerShape(12.dp)),
+                contentScale = ContentScale.Crop
+            )
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(
+                    text = "G1 Hub",
+                    color = HubPalette.OnBackground,
+                    style = MaterialTheme.typography.headlineMedium,
+                    fontWeight = FontWeight.Black
+                )
+                Text(
+                    text = "A hub for Basis applications",
+                    color = HubPalette.OnBackground.copy(alpha = 0.7f),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        Text(
+            text = "Choose an experience to launch",
+            color = HubPalette.OnBackground.copy(alpha = 0.75f),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold
+        )
+    }
+}
+
+@Composable
+private fun HubTileCard(tile: HubTile) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .aspectRatio(1f)
+            .clip(RoundedCornerShape(20.dp))
+            .clickable(onClick = tile.onClick),
+        colors = CardDefaults.cardColors(
+            containerColor = HubPalette.Surface,
+            contentColor = HubPalette.OnSurface
+        ),
+        border = CardDefaults.outlinedCardBorder().copy(
+            width = 2.dp,
+            color = HubPalette.CardAccent
+        )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.SpaceBetween,
+            horizontalAlignment = Alignment.Start
+        ) {
+            Icon(
+                imageVector = tile.icon,
+                contentDescription = null,
+                tint = HubPalette.Accent,
+            )
+            Column(
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Text(
+                    text = tile.title,
+                    color = HubPalette.OnSurface,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Text(
+                    text = tile.description,
+                    color = HubPalette.OnSurface.copy(alpha = 0.8f),
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+    }
+}
+
+private data class HubTile(
+    val title: String,
+    val description: String,
+    val icon: ImageVector,
+    val onClick: () -> Unit,
+)
+
+@Preview(showBackground = true)
+@Composable
+private fun HomeScreenPreview() {
+    HomeScreen(
+        onAssistantClick = {},
+        onSettingsClick = {},
+        onSubtitlesClick = {},
+        onTodoClick = {},
+        onNavigationClick = {},
+        onEReaderClick = {},
+        onNotificationsClick = {}
+    )
+}

--- a/hub/src/main/java/io/texne/g1/hub/ui/settings/SettingsScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/settings/SettingsScreen.kt
@@ -3,7 +3,6 @@ package io.texne.g1.hub.ui.settings
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -44,7 +43,7 @@ fun SettingsScreen(
 
     Column(
         modifier = modifier
-            .fillMaxSize()
+            .fillMaxWidth()
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {

--- a/hub/src/main/java/io/texne/g1/hub/ui/todo/TodoScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/todo/TodoScreen.kt
@@ -1,0 +1,291 @@
+package io.texne.g1.hub.ui.todo
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Archive
+import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material.icons.outlined.Restore
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Divider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.texne.g1.hub.todo.TodoItem
+import io.texne.g1.hub.ui.home.HubPalette
+
+@Composable
+fun TodoScreen(
+    modifier: Modifier = Modifier,
+    viewModel: TodoViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    TodoContent(
+        state = state,
+        onAddTask = viewModel::addTask,
+        onToggleTask = viewModel::toggleTask,
+        onArchiveTask = viewModel::archiveTask,
+        onRestoreTask = viewModel::restoreTask,
+        onDismissMessage = viewModel::consumeMessage,
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun TodoContent(
+    state: TodoState,
+    onAddTask: (String) -> Unit,
+    onToggleTask: (String) -> Unit,
+    onArchiveTask: (String) -> Unit,
+    onRestoreTask: (String) -> Unit,
+    onDismissMessage: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var newTaskText by rememberSaveable { mutableStateOf("") }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(HubPalette.Background)
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(
+            text = "Todo",
+            style = MaterialTheme.typography.headlineSmall,
+            color = HubPalette.OnBackground,
+            fontWeight = FontWeight.Bold
+        )
+        Text(
+            text = "Capture quick notes and action items for your day.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = HubPalette.OnBackground.copy(alpha = 0.75f)
+        )
+
+        Card(
+            colors = CardDefaults.cardColors(containerColor = HubPalette.Surface)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                OutlinedTextField(
+                    modifier = Modifier.fillMaxWidth(),
+                    value = newTaskText,
+                    onValueChange = { newTaskText = it },
+                    label = { Text("New task") }
+                )
+                Button(
+                    onClick = {
+                        onAddTask(newTaskText)
+                        newTaskText = ""
+                    },
+                    enabled = newTaskText.isNotBlank()
+                ) {
+                    Text("Add task")
+                }
+            }
+        }
+
+        state.errorMessage?.let { message ->
+            Surface(
+                color = HubPalette.Surface,
+                tonalElevation = 6.dp
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = message,
+                        color = HubPalette.OnSurface,
+                        modifier = Modifier.weight(1f)
+                    )
+                    TextButton(onClick = onDismissMessage) {
+                        Text("Dismiss")
+                    }
+                }
+            }
+        }
+
+        if (state.isLoading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                item {
+                    SectionHeader(title = "Active tasks")
+                }
+                if (state.activeTasks.isEmpty()) {
+                    item {
+                        Text(
+                            text = "You're all caught up!",
+                            color = HubPalette.OnBackground.copy(alpha = 0.7f),
+                            modifier = Modifier.padding(horizontal = 4.dp)
+                        )
+                    }
+                } else {
+                    items(state.activeTasks, key = { it.id }) { task ->
+                        ActiveTaskRow(
+                            task = task,
+                            onToggle = onToggleTask,
+                            onArchive = onArchiveTask
+                        )
+                    }
+                }
+
+                if (state.archivedTasks.isNotEmpty()) {
+                    item {
+                        Spacer(modifier = Modifier.height(16.dp))
+                        SectionHeader(title = "Archived")
+                    }
+                    items(state.archivedTasks, key = { it.id }) { task ->
+                        ArchivedTaskRow(
+                            task = task,
+                            onRestore = onRestoreTask
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleMedium,
+        color = HubPalette.OnBackground,
+        fontWeight = FontWeight.SemiBold
+    )
+}
+
+@Composable
+private fun ActiveTaskRow(
+    task: TodoItem,
+    onToggle: (String) -> Unit,
+    onArchive: (String) -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = HubPalette.Surface)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = task.shortText,
+                style = MaterialTheme.typography.titleMedium,
+                color = HubPalette.OnSurface,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = { onToggle(task.id) }) {
+                    Icon(
+                        imageVector = Icons.Outlined.CheckCircle,
+                        contentDescription = "Mark complete",
+                        tint = HubPalette.Accent
+                    )
+                }
+                IconButton(onClick = { onArchive(task.id) }) {
+                    Icon(
+                        imageVector = Icons.Outlined.Archive,
+                        contentDescription = "Archive",
+                        tint = HubPalette.OnSurface.copy(alpha = 0.7f)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ArchivedTaskRow(
+    task: TodoItem,
+    onRestore: (String) -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = HubPalette.Surface)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = task.shortText,
+                style = MaterialTheme.typography.bodyLarge,
+                color = HubPalette.OnSurface.copy(alpha = 0.8f),
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+            Divider(color = HubPalette.CardAccent)
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = { onRestore(task.id) }) {
+                    Icon(
+                        imageVector = Icons.Outlined.Restore,
+                        contentDescription = "Restore",
+                        tint = HubPalette.Accent
+                    )
+                }
+            }
+        }
+    }
+}

--- a/hub/src/main/java/io/texne/g1/hub/ui/todo/TodoViewModel.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/todo/TodoViewModel.kt
@@ -1,0 +1,112 @@
+package io.texne.g1.hub.ui.todo
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.texne.g1.hub.todo.TodoItem
+import io.texne.g1.hub.todo.TodoRepository
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class TodoViewModel @Inject constructor(
+    private val repository: TodoRepository
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(TodoState())
+    val state: StateFlow<TodoState> = _state.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            combine(
+                repository.activeTasks,
+                repository.archivedTasks
+            ) { active, archived ->
+                active to archived
+            }.collect { (active, archived) ->
+                _state.update {
+                    it.copy(
+                        isLoading = false,
+                        activeTasks = active,
+                        archivedTasks = archived
+                    )
+                }
+            }
+        }
+
+        viewModelScope.launch {
+            runCatching { repository.refresh() }
+                .onFailure {
+                    _state.update { state ->
+                        state.copy(
+                            isLoading = false,
+                            errorMessage = "Unable to load tasks."
+                        )
+                    }
+                }
+        }
+    }
+
+    fun addTask(text: String) {
+        val sanitized = text.trim()
+        if (sanitized.isEmpty()) return
+
+        viewModelScope.launch {
+            runCatching { repository.addTask(sanitized) }
+                .onFailure {
+                    _state.update { state ->
+                        state.copy(errorMessage = "Unable to add task.")
+                    }
+                }
+        }
+    }
+
+    fun toggleTask(id: String) {
+        viewModelScope.launch {
+            runCatching { repository.toggleTask(id) }
+                .onFailure {
+                    _state.update { state ->
+                        state.copy(errorMessage = "Unable to update task.")
+                    }
+                }
+        }
+    }
+
+    fun archiveTask(id: String) {
+        viewModelScope.launch {
+            runCatching { repository.archiveTask(id) }
+                .onFailure {
+                    _state.update { state ->
+                        state.copy(errorMessage = "Unable to archive task.")
+                    }
+                }
+        }
+    }
+
+    fun restoreTask(id: String) {
+        viewModelScope.launch {
+            runCatching { repository.restoreTask(id) }
+                .onFailure {
+                    _state.update { state ->
+                        state.copy(errorMessage = "Unable to restore task.")
+                    }
+                }
+        }
+    }
+
+    fun consumeMessage() {
+        _state.update { it.copy(errorMessage = null) }
+    }
+}
+
+data class TodoState(
+    val isLoading: Boolean = true,
+    val activeTasks: List<TodoItem> = emptyList(),
+    val archivedTasks: List<TodoItem> = emptyList(),
+    val errorMessage: String? = null,
+)


### PR DESCRIPTION
## Summary
- replace the tabbed ApplicationFrame with a scaffolded flow backed by a sealed AppDestination and green top app bar
- add a HUD-styled HomeScreen grid plus subtitles launcher and coming-soon placeholders for future modules
- implement a Todo workflow backed by TodoRepository and embed the glasses connection flow within settings

## Testing
- ./gradlew :hub:compileDebugKotlin *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd862f01908332b71c56496370cba0