### PR TITLE
Add HUD gesture handling and tie gestures to assistant prompts

### DIFF
--- a/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/GestureCallback.aidl
+++ b/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/GestureCallback.aidl
@@ -1,0 +1,10 @@
+// GestureCallback.aidl
+package io.texne.g1.basis.service.protocol;
+
+/** Callback invoked by the service when a HUD gesture is detected. */
+interface GestureCallback {
+    /**
+     * @param gesture Wire value matching [HudGesture.wireValue].
+     */
+    void onGesture(int gesture);
+}

--- a/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/IG1Service.aidl
+++ b/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/IG1Service.aidl
@@ -1,6 +1,7 @@
 // IG1Service.aidl
 package io.texne.g1.basis.service.protocol;
 
+import io.texne.g1.basis.service.protocol.GestureCallback;
 import io.texne.g1.basis.service.protocol.ObserveStateCallback;
 import io.texne.g1.basis.service.protocol.OperationCallback;
 
@@ -11,4 +12,5 @@ interface IG1Service {
     void disconnectGlasses(String id, @nullable OperationCallback callback);
     void displayTextPage(String id, in String[] page, @nullable OperationCallback callback);
     void stopDisplaying(String id, @nullable OperationCallback callback);
+    void observeHudGestures(GestureCallback callback);
 }

--- a/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/IG1ServiceClient.aidl
+++ b/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/IG1ServiceClient.aidl
@@ -1,6 +1,7 @@
 // IG1ServiceClient.aidl
 package io.texne.g1.basis.service.protocol;
 
+import io.texne.g1.basis.service.protocol.GestureCallback;
 import io.texne.g1.basis.service.protocol.ObserveStateCallback;
 import io.texne.g1.basis.service.protocol.OperationCallback;
 
@@ -8,4 +9,5 @@ interface IG1ServiceClient {
     void observeState(ObserveStateCallback callback);
     void displayTextPage(String id, in String[] page, @nullable OperationCallback callback);
     void stopDisplaying(String id, @nullable OperationCallback callback);
+    void observeHudGestures(GestureCallback callback);
 }

--- a/aidl/src/main/java/io/texne/g1/basis/service/protocol/HudGesture.kt
+++ b/aidl/src/main/java/io/texne/g1/basis/service/protocol/HudGesture.kt
@@ -1,0 +1,23 @@
+package io.texne.g1.basis.service.protocol
+
+/**
+ * Gestures originating from the G1 glasses HUD touchpad.
+ *
+ * Values map to the wire protocol integers delivered by the service layer via AIDL.
+ */
+enum class HudGesture(val wireValue: Int) {
+    /** Primary activation gesture, e.g. a single tap. */
+    ACTIVATE(0),
+
+    /** Navigate forward within an interactive HUD experience (e.g. swipe forward). */
+    NEXT_PAGE(1),
+
+    /** Navigate backward within an interactive HUD experience (e.g. swipe back). */
+    PREVIOUS_PAGE(2);
+
+    companion object {
+        fun fromWireValue(value: Int): HudGesture? = entries.firstOrNull { it.wireValue == value }
+    }
+}
+
+fun HudGesture.toWireValue(): Int = wireValue

--- a/core/src/main/java/io/texne/g1/basis/core/G1.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/G1.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.merge
 import no.nordicsemi.android.support.v18.scanner.BluetoothLeScannerCompat
 import no.nordicsemi.android.support.v18.scanner.ScanCallback
 import no.nordicsemi.android.support.v18.scanner.ScanResult
@@ -54,6 +55,7 @@ class G1 {
     )
     val state: StateFlow<State>
     private var currentState: State? = null
+    val gestures = merge(left.gestures, right.gestures)
 
     // construction --------------------------------------------------------------------------------
 

--- a/core/src/main/java/io/texne/g1/basis/core/Gesture.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/Gesture.kt
@@ -1,0 +1,24 @@
+package io.texne.g1.basis.core
+
+/**
+ * Gestures detected from unsolicited packets emitted by the G1 glasses.
+ */
+enum class GlassesGesture(val rawCode: Int) {
+    SINGLE_TAP(0x01),
+    DOUBLE_TAP(0x02),
+    SWIPE_FORWARD(0x03),
+    SWIPE_BACK(0x04),
+    LONG_PRESS(0x05),
+    UNKNOWN(-1);
+
+    companion object {
+        fun fromRaw(rawCode: Int): GlassesGesture = when (rawCode) {
+            SINGLE_TAP.rawCode -> SINGLE_TAP
+            DOUBLE_TAP.rawCode -> DOUBLE_TAP
+            SWIPE_FORWARD.rawCode -> SWIPE_FORWARD
+            SWIPE_BACK.rawCode -> SWIPE_BACK
+            LONG_PRESS.rawCode -> LONG_PRESS
+            else -> UNKNOWN
+        }
+    }
+}

--- a/core/src/main/java/io/texne/g1/basis/core/protocol.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/protocol.kt
@@ -77,6 +77,7 @@ enum class IncomingPacketType(
     EXIT("EXIT", hasFirst(0x18), { ExitResponsePacket(it) }),
     GLASSES_BATTERY_LEVEL("GLASSES_BATTERY_LEVEL", hasFirstTwo(0x2C, 0x66), { BatteryLevelResponsePacket(it) }),
     AI_RESULT_RECEIVED("AI_RESULT_RECEIVED", hasFirst(0x4E), { SendTextResponsePacket(it) }),
+    GESTURE_EVENT("GESTURE_EVENT", hasFirst(0x29), { GesturePacket(it) }),
 ;
     override fun toString() = label
 }
@@ -188,3 +189,16 @@ class SendTextResponsePacket(bytes: ByteArray): IncomingPacket(
     bytes,
     OutgoingPacketType.SEND_AI_RESULT
 )
+
+// gestures -----------------------------------------------------------------------------------------
+
+class GesturePacket(bytes: ByteArray): IncomingPacket(
+    IncomingPacketType.GESTURE_EVENT,
+    bytes
+) {
+    val gesture: GlassesGesture = GlassesGesture.fromRaw(bytes.getOrNull(1)?.toInt() ?: -1)
+
+    override fun toString(): String {
+        return "${type} => ${gesture} (${bytes.joinToString(separator = " ") { String.format("%02x", it) }})"
+    }
+}

--- a/hub/src/main/java/io/texne/g1/hub/ui/chat/ChatScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/chat/ChatScreen.kt
@@ -33,9 +33,6 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -60,6 +57,7 @@ fun ChatScreen(
         connectedGlassesName = connectedGlassesName,
         onPersonaSelected = viewModel::onPersonaSelected,
         onSendPrompt = viewModel::sendPrompt,
+        onPromptChanged = viewModel::onPromptChanged,
         onNavigateToSettings = onNavigateToSettings,
         onDismissError = viewModel::clearError,
         onHudStatusConsumed = viewModel::clearHudStatus
@@ -72,12 +70,12 @@ private fun ChatContent(
     connectedGlassesName: String?,
     onPersonaSelected: (ChatPersona) -> Unit,
     onSendPrompt: (String) -> Unit,
+    onPromptChanged: (String) -> Unit,
     onNavigateToSettings: () -> Unit,
     onDismissError: () -> Unit,
     onHudStatusConsumed: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    var prompt by rememberSaveable { mutableStateOf("") }
     val listState = rememberLazyListState()
 
     LaunchedEffect(state.messages.size) {
@@ -188,8 +186,8 @@ private fun ChatContent(
         ) {
             OutlinedTextField(
                 modifier = Modifier.weight(1f),
-                value = prompt,
-                onValueChange = { prompt = it },
+                value = state.promptDraft,
+                onValueChange = onPromptChanged,
                 label = { Text("Ask the assistant") },
                 maxLines = 3,
                 supportingText = {
@@ -204,12 +202,11 @@ private fun ChatContent(
                 }
             )
 
-            val sendEnabled = prompt.isNotBlank() && state.apiKeyAvailable && !state.isSending
+            val sendEnabled = state.promptDraft.isNotBlank() && state.apiKeyAvailable && !state.isSending
             IconButton(
                 onClick = {
                     if (sendEnabled) {
-                        onSendPrompt(prompt.trim())
-                        prompt = ""
+                        onSendPrompt(state.promptDraft)
                     }
                 },
                 enabled = sendEnabled

--- a/hub/src/test/java/io/texne/g1/hub/ui/chat/ChatViewModelTest.kt
+++ b/hub/src/test/java/io/texne/g1/hub/ui/chat/ChatViewModelTest.kt
@@ -5,10 +5,12 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.texne.g1.basis.service.protocol.HudGesture
 import io.texne.g1.hub.MainDispatcherRule
 import io.texne.g1.hub.ai.ChatGptRepository
 import io.texne.g1.hub.ai.ChatPersona
 import io.texne.g1.hub.model.Repository
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -28,11 +30,14 @@ class ChatViewModelTest {
     lateinit var serviceRepository: Repository
 
     private val apiKeyFlow = MutableStateFlow<String?>("test-key")
+    private lateinit var gestureEvents: MutableSharedFlow<HudGesture>
 
     @BeforeTest
     fun setUp() {
         MockKAnnotations.init(this, relaxUnitFun = true)
         every { chatRepository.observeApiKey() } returns apiKeyFlow
+        gestureEvents = MutableSharedFlow()
+        every { serviceRepository.observeHudGestures() } returns gestureEvents
     }
 
     @Test
@@ -71,5 +76,83 @@ class ChatViewModelTest {
         advanceUntilIdle()
 
         coVerify(exactly = 0) { serviceRepository.displayCenteredPageOnConnectedGlasses(any(), any()) }
+    }
+
+    @Test
+    fun `gesture next page routes to repository`() = runTest {
+        val viewModel = ChatViewModel(chatRepository, serviceRepository)
+        val persona = ChatPersona(
+            id = "todo",
+            displayName = "Todo",
+            description = "",
+            systemPrompt = "",
+            hudHoldMillis = null
+        )
+        viewModel.onPersonaSelected(persona)
+
+        val response = "Item one. Item two. Item three. Item four. Item five. Item six."
+        coEvery { chatRepository.requestChatCompletion(persona, any()) } returns Result.success(response)
+        coEvery { serviceRepository.displayCenteredOnConnectedGlasses(any(), any()) } returns true
+        coEvery { serviceRepository.displayCenteredPageOnConnectedGlasses(any(), any()) } returns true
+
+        viewModel.sendPrompt("show my todo list")
+        advanceUntilIdle()
+
+        gestureEvents.emit(HudGesture.NEXT_PAGE)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            serviceRepository.displayCenteredPageOnConnectedGlasses(match { it.size > 1 }, 1)
+        }
+    }
+
+    @Test
+    fun `gesture previous page routes to repository`() = runTest {
+        val viewModel = ChatViewModel(chatRepository, serviceRepository)
+        val persona = ChatPersona(
+            id = "todo",
+            displayName = "Todo",
+            description = "",
+            systemPrompt = "",
+            hudHoldMillis = null
+        )
+        viewModel.onPersonaSelected(persona)
+
+        val response = "Item one. Item two. Item three. Item four. Item five. Item six."
+        coEvery { chatRepository.requestChatCompletion(persona, any()) } returns Result.success(response)
+        coEvery { serviceRepository.displayCenteredOnConnectedGlasses(any(), any()) } returns true
+        coEvery { serviceRepository.displayCenteredPageOnConnectedGlasses(any(), any()) } returns true
+
+        viewModel.sendPrompt("show my todo list")
+        advanceUntilIdle()
+
+        gestureEvents.emit(HudGesture.NEXT_PAGE)
+        advanceUntilIdle()
+        gestureEvents.emit(HudGesture.PREVIOUS_PAGE)
+        advanceUntilIdle()
+
+        coVerify { serviceRepository.displayCenteredPageOnConnectedGlasses(match { it.size > 1 }, 0) }
+    }
+
+    @Test
+    fun `activation gesture sends draft prompt`() = runTest {
+        val viewModel = ChatViewModel(chatRepository, serviceRepository)
+        viewModel.onPromptChanged("Hello world")
+        coEvery { chatRepository.requestChatCompletion(any(), any()) } returns Result.failure(Exception("fail"))
+
+        gestureEvents.emit(HudGesture.ACTIVATE)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { chatRepository.requestChatCompletion(any(), any()) }
+    }
+
+    @Test
+    fun `activation gesture ignored when prompt blank`() = runTest {
+        val viewModel = ChatViewModel(chatRepository, serviceRepository)
+
+        gestureEvents.emit(HudGesture.ACTIVATE)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { chatRepository.requestChatCompletion(any(), any()) }
     }
 }


### PR DESCRIPTION
## Summary
- define HUD gesture AIDL contract and map BLE gesture packets to high-level events
- expose gesture flow through the service client/repository and have ChatViewModel react to activation and page navigation gestures
- track the chat prompt inside the ViewModel so gestures can trigger prompt sends, and update UI/tests accordingly

## Testing
- ./gradlew :hub:test *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8c5cc6a083328cea7fa0fc1bd83b