### PR TITLE
Add assistant activation gesture preferences

### DIFF
--- a/hub/src/main/java/io/texne/g1/hub/G1HubApplication.kt
+++ b/hub/src/main/java/io/texne/g1/hub/G1HubApplication.kt
@@ -6,11 +6,13 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.HiltAndroidApp
 import dagger.hilt.components.SingletonComponent
+import io.texne.g1.hub.BuildConfig
+import io.texne.g1.hub.assistant.AssistantActivationGesture
+import io.texne.g1.hub.assistant.AssistantPreferences
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.StateFlow
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
-import javax.inject.Singleton
-
-import io.texne.g1.hub.BuildConfig
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -30,6 +32,13 @@ object GlobalModule {
             .addInterceptor(logging)
             .build()
     }
+
+    @Provides
+    @Singleton
+    fun provideAssistantActivationGesture(
+        assistantPreferences: AssistantPreferences
+    ): StateFlow<AssistantActivationGesture> =
+        assistantPreferences.observeActivationGesture()
 }
 
 @HiltAndroidApp

--- a/hub/src/main/java/io/texne/g1/hub/assistant/AssistantActivationGesture.kt
+++ b/hub/src/main/java/io/texne/g1/hub/assistant/AssistantActivationGesture.kt
@@ -1,0 +1,12 @@
+package io.texne.g1.hub.assistant
+
+import androidx.annotation.StringRes
+import io.texne.g1.hub.R
+
+enum class AssistantActivationGesture(@StringRes val labelRes: Int) {
+    OFF(R.string.settings_assistant_activation_option_off),
+    SINGLE(R.string.settings_assistant_activation_option_single),
+    DOUBLE(R.string.settings_assistant_activation_option_double),
+    TRIPLE(R.string.settings_assistant_activation_option_triple),
+    HOLD(R.string.settings_assistant_activation_option_hold);
+}

--- a/hub/src/main/java/io/texne/g1/hub/assistant/AssistantPreferences.kt
+++ b/hub/src/main/java/io/texne/g1/hub/assistant/AssistantPreferences.kt
@@ -1,0 +1,60 @@
+package io.texne.g1.hub.assistant
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withContext
+
+@Singleton
+class AssistantPreferences @Inject constructor(
+    @ApplicationContext context: Context
+) {
+    private val sharedPreferences: SharedPreferences =
+        context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+
+    private val activationGestureFlow = MutableStateFlow(readGesture())
+
+    private val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+        if (key == KEY_ACTIVATION_GESTURE) {
+            activationGestureFlow.value = readGesture()
+        }
+    }
+
+    init {
+        sharedPreferences.registerOnSharedPreferenceChangeListener(listener)
+    }
+
+    fun observeActivationGesture(): StateFlow<AssistantActivationGesture> =
+        activationGestureFlow.asStateFlow()
+
+    fun getActivationGesture(): AssistantActivationGesture = readGesture()
+
+    suspend fun setActivationGesture(gesture: AssistantActivationGesture) =
+        withContext(Dispatchers.IO) {
+            sharedPreferences.edit(commit = true) {
+                if (gesture == AssistantActivationGesture.OFF) {
+                    remove(KEY_ACTIVATION_GESTURE)
+                } else {
+                    putString(KEY_ACTIVATION_GESTURE, gesture.name)
+                }
+            }
+        }
+
+    private fun readGesture(): AssistantActivationGesture {
+        val stored = sharedPreferences.getString(KEY_ACTIVATION_GESTURE, null)
+        return stored?.let { runCatching { AssistantActivationGesture.valueOf(it) }.getOrNull() }
+            ?: AssistantActivationGesture.OFF
+    }
+
+    private companion object {
+        private const val PREF_NAME = "assistant_preferences"
+        private const val KEY_ACTIVATION_GESTURE = "activation_gesture"
+    }
+}

--- a/hub/src/main/java/io/texne/g1/hub/ui/settings/SettingsScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/settings/SettingsScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
@@ -18,6 +19,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -30,9 +32,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.texne.g1.hub.assistant.AssistantActivationGesture
+import io.texne.g1.hub.R
 
 @Composable
 fun SettingsScreen(
@@ -101,6 +107,11 @@ fun SettingsScreen(
             StatusMessage(message = message, onDismiss = viewModel::consumeMessage)
         }
 
+        AssistantActivationCard(
+            selectedGesture = state.activationGesture,
+            onGestureSelected = viewModel::setActivationGesture
+        )
+
         Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
             Column(
                 modifier = Modifier.padding(16.dp),
@@ -120,6 +131,68 @@ fun SettingsScreen(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun AssistantActivationCard(
+    selectedGesture: AssistantActivationGesture,
+    onGestureSelected: (AssistantActivationGesture) -> Unit
+) {
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(
+                text = stringResource(id = R.string.settings_assistant_activation_title),
+                style = MaterialTheme.typography.titleSmall
+            )
+            Text(
+                text = stringResource(id = R.string.settings_assistant_activation_description),
+                style = MaterialTheme.typography.bodySmall
+            )
+
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                AssistantActivationGesture.entries.forEach { gesture ->
+                    AssistantActivationOption(
+                        gesture = gesture,
+                        selected = gesture == selectedGesture,
+                        onSelected = onGestureSelected
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AssistantActivationOption(
+    gesture: AssistantActivationGesture,
+    selected: Boolean,
+    onSelected: (AssistantActivationGesture) -> Unit
+) {
+    val label = stringResource(id = gesture.labelRes)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .selectable(
+                selected = selected,
+                onClick = { onSelected(gesture) },
+                role = Role.RadioButton
+            )
+            .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        RadioButton(
+            selected = selected,
+            onClick = null
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium
+        )
     }
 }
 

--- a/hub/src/main/java/io/texne/g1/hub/ui/settings/SettingsViewModel.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/settings/SettingsViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.texne.g1.hub.ai.ChatGptRepository
+import io.texne.g1.hub.assistant.AssistantActivationGesture
+import io.texne.g1.hub.assistant.AssistantPreferences
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -14,13 +16,15 @@ import kotlinx.coroutines.launch
 
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
-    private val chatRepository: ChatGptRepository
+    private val chatRepository: ChatGptRepository,
+    private val assistantPreferences: AssistantPreferences
 ) : ViewModel() {
 
     data class State(
         val currentKey: String = "",
         val inputKey: String = "",
         val isSaving: Boolean = false,
+        val activationGesture: AssistantActivationGesture = AssistantActivationGesture.OFF,
         val message: String? = null
     )
 
@@ -35,6 +39,14 @@ class SettingsViewModel @Inject constructor(
                         currentKey = key.orEmpty(),
                         inputKey = key.orEmpty()
                     )
+                }
+            }
+        }
+
+        viewModelScope.launch {
+            assistantPreferences.observeActivationGesture().collectLatest { gesture ->
+                _state.update { state ->
+                    state.copy(activationGesture = gesture)
                 }
             }
         }
@@ -63,6 +75,17 @@ class SettingsViewModel @Inject constructor(
             _state.update { it.copy(inputKey = "", isSaving = true, message = null) }
             chatRepository.updateApiKey(null)
             _state.update { it.copy(isSaving = false, message = "Stored key removed.") }
+        }
+    }
+
+    fun setActivationGesture(gesture: AssistantActivationGesture) {
+        if (_state.value.activationGesture == gesture) {
+            return
+        }
+
+        viewModelScope.launch {
+            _state.update { it.copy(activationGesture = gesture) }
+            assistantPreferences.setActivationGesture(gesture)
         }
     }
 

--- a/hub/src/main/res/values/strings.xml
+++ b/hub/src/main/res/values/strings.xml
@@ -1,3 +1,10 @@
 <resources>
     <string name="app_name">G1 Hub</string>
+    <string name="settings_assistant_activation_title">Assistant activation</string>
+    <string name="settings_assistant_activation_description">Choose how to open the assistant from your glasses.</string>
+    <string name="settings_assistant_activation_option_off">Off</string>
+    <string name="settings_assistant_activation_option_single">Single tap</string>
+    <string name="settings_assistant_activation_option_double">Double tap</string>
+    <string name="settings_assistant_activation_option_triple">Triple tap</string>
+    <string name="settings_assistant_activation_option_hold">Tap and hold</string>
 </resources>


### PR DESCRIPTION
## Summary
- add AssistantPreferences for persisting the selected assistant activation gesture
- expose and edit the gesture from SettingsViewModel and SettingsScreen
- provide the gesture via Hilt so downstream gesture handling can consume it

## Testing
- `./gradlew :hub:lint` *(fails: Android SDK is not available in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9145f6bc83329b562cfdf7664fb5