### PR TITLE
Add gesture streaming to assistant activation pipeline

### DIFF
--- a/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/G1GestureEvent.aidl
+++ b/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/G1GestureEvent.aidl
@@ -1,0 +1,15 @@
+// G1GestureEvent.aidl
+package io.texne.g1.basis.service.protocol;
+
+parcelable G1GestureEvent {
+    const int TYPE_TAP = 1;
+    const int TYPE_HOLD = 2;
+
+    const int SIDE_LEFT = 1;
+    const int SIDE_RIGHT = 2;
+
+    int sequence;
+    int type;
+    int side;
+    long timestampMillis;
+}

--- a/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/G1ServiceState.aidl
+++ b/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/G1ServiceState.aidl
@@ -2,6 +2,7 @@
 package io.texne.g1.basis.service.protocol;
 
 import io.texne.g1.basis.service.protocol.G1Glasses;
+import io.texne.g1.basis.service.protocol.G1GestureEvent;
 
 parcelable G1ServiceState {
     const int READY = 1;
@@ -11,4 +12,5 @@ parcelable G1ServiceState {
 
     int status;
     G1Glasses[] glasses;
+    G1GestureEvent gestureEvent;
 }

--- a/core/src/main/java/io/texne/g1/basis/core/G1Gesture.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/G1Gesture.kt
@@ -1,0 +1,25 @@
+package io.texne.g1.basis.core
+
+sealed class G1Gesture(
+    open val side: Side,
+    open val timestampMillis: Long
+) {
+    abstract val type: Type
+
+    enum class Type { TAP, HOLD }
+    enum class Side { LEFT, RIGHT }
+
+    data class Tap(
+        override val side: Side,
+        override val timestampMillis: Long
+    ): G1Gesture(side, timestampMillis) {
+        override val type: Type = Type.TAP
+    }
+
+    data class Hold(
+        override val side: Side,
+        override val timestampMillis: Long
+    ): G1Gesture(side, timestampMillis) {
+        override val type: Type = Type.HOLD
+    }
+}

--- a/core/src/main/java/io/texne/g1/basis/core/protocol.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/protocol.kt
@@ -72,13 +72,13 @@ internal fun hasFirstTwo(first: Byte, second: Byte): (ByteArray) -> Boolean = { 
 enum class IncomingPacketType(
     val label: String,
     val isType: (bytes: ByteArray) -> Boolean,
-    val factory: IncomingPacketType.(bytes: ByteArray) -> IncomingPacket?
+    val factory: (type: IncomingPacketType, bytes: ByteArray) -> IncomingPacket?
 ) {
-    EXIT("EXIT", hasFirst(0x18), { bytes -> ExitResponsePacket(bytes) }),
-    GLASSES_BATTERY_LEVEL("GLASSES_BATTERY_LEVEL", hasFirstTwo(0x2C, 0x66), { bytes -> BatteryLevelResponsePacket(bytes) }),
-    AI_RESULT_RECEIVED("AI_RESULT_RECEIVED", hasFirst(0x4E), { bytes -> SendTextResponsePacket(bytes) }),
-    GESTURE_TAP("GESTURE_TAP", hasFirst(0x29), { bytes -> GesturePacket(this, bytes, G1Gesture.Type.TAP) }),
-    GESTURE_HOLD("GESTURE_HOLD", hasFirst(0x2B), { bytes -> GesturePacket(this, bytes, G1Gesture.Type.HOLD) }),
+    EXIT("EXIT", hasFirst(0x18), { _, bytes -> ExitResponsePacket(bytes) }),
+    GLASSES_BATTERY_LEVEL("GLASSES_BATTERY_LEVEL", hasFirstTwo(0x2C, 0x66), { _, bytes -> BatteryLevelResponsePacket(bytes) }),
+    AI_RESULT_RECEIVED("AI_RESULT_RECEIVED", hasFirst(0x4E), { _, bytes -> SendTextResponsePacket(bytes) }),
+    GESTURE_TAP("GESTURE_TAP", hasFirst(0x29), { type, bytes -> GesturePacket(type, bytes, G1Gesture.Type.TAP) }),
+    GESTURE_HOLD("GESTURE_HOLD", hasFirst(0x2B), { type, bytes -> GesturePacket(type, bytes, G1Gesture.Type.HOLD) }),
 ;
     override fun toString() = label
 }
@@ -151,7 +151,7 @@ abstract class IncomingPacket(val type: IncomingPacketType, val bytes: ByteArray
     companion object {
         fun fromBytes(bytes: ByteArray): IncomingPacket? =
             IncomingPacketType.entries.firstOrNull { it.isType(bytes) }?.let { type ->
-                type.factory(bytes)
+                type.factory(type, bytes)
             }
     }
 }

--- a/core/src/main/java/io/texne/g1/basis/core/protocol.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/protocol.kt
@@ -72,13 +72,13 @@ internal fun hasFirstTwo(first: Byte, second: Byte): (ByteArray) -> Boolean = { 
 enum class IncomingPacketType(
     val label: String,
     val isType: (bytes: ByteArray) -> Boolean,
-    val factory: (bytes: ByteArray) -> (IncomingPacket?)
+    val factory: IncomingPacketType.(bytes: ByteArray) -> IncomingPacket?
 ) {
-    EXIT("EXIT", hasFirst(0x18), { ExitResponsePacket(it) }),
-    GLASSES_BATTERY_LEVEL("GLASSES_BATTERY_LEVEL", hasFirstTwo(0x2C, 0x66), { BatteryLevelResponsePacket(it) }),
-    AI_RESULT_RECEIVED("AI_RESULT_RECEIVED", hasFirst(0x4E), { SendTextResponsePacket(it) }),
-    GESTURE_TAP("GESTURE_TAP", hasFirst(0x29), { GesturePacket(this@IncomingPacketType, it, G1Gesture.Type.TAP) }),
-    GESTURE_HOLD("GESTURE_HOLD", hasFirst(0x2B), { GesturePacket(this@IncomingPacketType, it, G1Gesture.Type.HOLD) }),
+    EXIT("EXIT", hasFirst(0x18), { bytes -> ExitResponsePacket(bytes) }),
+    GLASSES_BATTERY_LEVEL("GLASSES_BATTERY_LEVEL", hasFirstTwo(0x2C, 0x66), { bytes -> BatteryLevelResponsePacket(bytes) }),
+    AI_RESULT_RECEIVED("AI_RESULT_RECEIVED", hasFirst(0x4E), { bytes -> SendTextResponsePacket(bytes) }),
+    GESTURE_TAP("GESTURE_TAP", hasFirst(0x29), { bytes -> GesturePacket(this, bytes, G1Gesture.Type.TAP) }),
+    GESTURE_HOLD("GESTURE_HOLD", hasFirst(0x2B), { bytes -> GesturePacket(this, bytes, G1Gesture.Type.HOLD) }),
 ;
     override fun toString() = label
 }
@@ -150,7 +150,9 @@ class SendTextPacket(
 abstract class IncomingPacket(val type: IncomingPacketType, val bytes: ByteArray, val responseTo: OutgoingPacketType? = null) {
     companion object {
         fun fromBytes(bytes: ByteArray): IncomingPacket? =
-            IncomingPacketType.entries.firstOrNull { it.isType(bytes) }?.factory?.invoke(bytes)
+            IncomingPacketType.entries.firstOrNull { it.isType(bytes) }?.let { type ->
+                type.factory(bytes)
+            }
     }
 }
 

--- a/core/src/main/java/io/texne/g1/basis/core/protocol.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/protocol.kt
@@ -77,6 +77,8 @@ enum class IncomingPacketType(
     EXIT("EXIT", hasFirst(0x18), { ExitResponsePacket(it) }),
     GLASSES_BATTERY_LEVEL("GLASSES_BATTERY_LEVEL", hasFirstTwo(0x2C, 0x66), { BatteryLevelResponsePacket(it) }),
     AI_RESULT_RECEIVED("AI_RESULT_RECEIVED", hasFirst(0x4E), { SendTextResponsePacket(it) }),
+    GESTURE_TAP("GESTURE_TAP", hasFirst(0x29), { GesturePacket(this@IncomingPacketType, it, G1Gesture.Type.TAP) }),
+    GESTURE_HOLD("GESTURE_HOLD", hasFirst(0x2B), { GesturePacket(this@IncomingPacketType, it, G1Gesture.Type.HOLD) }),
 ;
     override fun toString() = label
 }
@@ -188,3 +190,13 @@ class SendTextResponsePacket(bytes: ByteArray): IncomingPacket(
     bytes,
     OutgoingPacketType.SEND_AI_RESULT
 )
+
+// gestures
+
+class GesturePacket(
+    type: IncomingPacketType,
+    bytes: ByteArray,
+    val gestureType: G1Gesture.Type,
+): IncomingPacket(type, bytes) {
+    val timestampMillis: Long = System.currentTimeMillis()
+}

--- a/hub/src/main/java/io/texne/g1/hub/preferences/AssistantPreferences.kt
+++ b/hub/src/main/java/io/texne/g1/hub/preferences/AssistantPreferences.kt
@@ -1,0 +1,69 @@
+package io.texne.g1.hub.preferences
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.texne.g1.basis.client.G1ServiceCommon
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withContext
+
+@Singleton
+class AssistantPreferences @Inject constructor(
+    @ApplicationContext context: Context
+) {
+    private val masterKey = MasterKey.Builder(context)
+        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+        .build()
+
+    private val sharedPreferences: SharedPreferences = EncryptedSharedPreferences.create(
+        context,
+        PREF_NAME,
+        masterKey,
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+    )
+
+    private val activationGestureFlow = MutableStateFlow(loadGesture())
+
+    private val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+        if (key == KEY_ACTIVATION_GESTURE) {
+            activationGestureFlow.value = loadGesture()
+        }
+    }
+
+    init {
+        sharedPreferences.registerOnSharedPreferenceChangeListener(listener)
+    }
+
+    fun observeActivationGesture(): StateFlow<G1ServiceCommon.GestureType> =
+        activationGestureFlow.asStateFlow()
+
+    fun currentActivationGesture(): G1ServiceCommon.GestureType = activationGestureFlow.value
+
+    suspend fun setActivationGesture(gesture: G1ServiceCommon.GestureType) = withContext(Dispatchers.IO) {
+        sharedPreferences.edit(commit = true) {
+            putString(KEY_ACTIVATION_GESTURE, gesture.name)
+        }
+    }
+
+    private fun loadGesture(): G1ServiceCommon.GestureType {
+        val stored = sharedPreferences.getString(KEY_ACTIVATION_GESTURE, null)
+        return stored?.let { value ->
+            runCatching { G1ServiceCommon.GestureType.valueOf(value) }.getOrNull()
+        } ?: DEFAULT_GESTURE
+    }
+
+    companion object {
+        private const val PREF_NAME = "assistant_preferences"
+        private const val KEY_ACTIVATION_GESTURE = "assistant_activation_gesture"
+        private val DEFAULT_GESTURE = G1ServiceCommon.GestureType.HOLD
+    }
+}

--- a/hub/src/main/java/io/texne/g1/hub/ui/ApplicationFrame.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/ApplicationFrame.kt
@@ -17,9 +17,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -36,19 +33,18 @@ import io.texne.g1.hub.ui.settings.SettingsScreen
 @Composable
 fun ApplicationFrame() {
     val viewModel = hiltViewModel<ApplicationViewModel>()
-    val state = viewModel.state.collectAsState().value
-
-    var selectedSection by rememberSaveable { mutableStateOf(AppSection.GLASSES) }
+    val state by viewModel.state.collectAsState()
+    val selectedSection = state.selectedSection
 
     Column(
         modifier = Modifier.fillMaxSize()
     ) {
         Header(
             selectedSection = selectedSection,
-            onSectionSelected = { selectedSection = it }
+            onSectionSelected = viewModel::selectSection
         )
 
-        val connectedGlasses = state?.connectedGlasses
+        val connectedGlasses = state.connectedGlasses
 
         when (selectedSection) {
             AppSection.GLASSES -> {
@@ -59,9 +55,9 @@ fun ApplicationFrame() {
                     )
                 } else {
                     ScannerScreen(
-                        scanning = state?.scanning == true,
-                        error = state?.error == true,
-                        nearbyGlasses = state?.nearbyGlasses,
+                        scanning = state.scanning,
+                        error = state.error,
+                        nearbyGlasses = state.nearbyGlasses,
                         scan = { viewModel.scan() },
                         connect = { viewModel.connect(it) },
                     )
@@ -70,7 +66,7 @@ fun ApplicationFrame() {
             AppSection.ASSISTANT -> {
                 ChatScreen(
                     connectedGlassesName = connectedGlasses?.name,
-                    onNavigateToSettings = { selectedSection = AppSection.SETTINGS }
+                    onNavigateToSettings = { viewModel.selectSection(AppSection.SETTINGS) }
                 )
             }
             AppSection.SETTINGS -> {

--- a/hub/src/main/java/io/texne/g1/hub/ui/ApplicationViewModel.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/ApplicationViewModel.kt
@@ -6,32 +6,52 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import io.texne.g1.basis.client.G1ServiceCommon
 import io.texne.g1.basis.client.G1ServiceCommon.ServiceStatus
 import io.texne.g1.hub.model.Repository
+import io.texne.g1.hub.preferences.AssistantPreferences
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class ApplicationViewModel @Inject constructor(
-    private val repository: Repository
+    private val repository: Repository,
+    private val assistantPreferences: AssistantPreferences
 ): ViewModel() {
 
     data class State(
         val connectedGlasses: G1ServiceCommon.Glasses? = null,
         val error: Boolean = false,
         val scanning: Boolean = false,
-        val nearbyGlasses: List<G1ServiceCommon.Glasses>? = null
+        val nearbyGlasses: List<G1ServiceCommon.Glasses>? = null,
+        val selectedSection: AppSection = AppSection.GLASSES
     )
 
-    val state = repository.getServiceStateFlow().map {
+    private val selectedSection = MutableStateFlow(AppSection.GLASSES)
+
+    private val activationEvents = MutableSharedFlow<G1ServiceCommon.GestureEvent>(
+        replay = 0,
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+
+    val assistantActivationEvents = activationEvents.asSharedFlow()
+
+    private val activationPreference = assistantPreferences.observeActivationGesture()
+
+    val state = repository.getServiceStateFlow().combine(selectedSection) { serviceState, section ->
         State(
-            connectedGlasses = it?.glasses?.filter { it.status == G1ServiceCommon.GlassesStatus.CONNECTED }?.firstOrNull(),
-            error = it?.status == ServiceStatus.ERROR,
-            scanning = it?.status == ServiceStatus.LOOKING,
-            nearbyGlasses = if(it == null || it.status == ServiceStatus.READY) null else it.glasses
+            connectedGlasses = serviceState?.glasses?.firstOrNull { it.status == G1ServiceCommon.GlassesStatus.CONNECTED },
+            error = serviceState?.status == ServiceStatus.ERROR,
+            scanning = serviceState?.status == ServiceStatus.LOOKING,
+            nearbyGlasses = if(serviceState == null || serviceState.status == ServiceStatus.READY) null else serviceState.glasses,
+            selectedSection = section
         )
-    }.stateIn(viewModelScope, SharingStarted.Lazily, null)
+    }.stateIn(viewModelScope, SharingStarted.Lazily, State())
 
     fun scan() {
         repository.startLooking()
@@ -45,5 +65,23 @@ class ApplicationViewModel @Inject constructor(
 
     fun disconnect(id: String) {
         repository.disconnectGlasses(id)
+    }
+
+    fun selectSection(section: AppSection) {
+        selectedSection.value = section
+    }
+
+    init {
+        viewModelScope.launch {
+            repository.gestureEvents().collect { gesture ->
+                val preferred = activationPreference.value
+                if(gesture.type == preferred && gesture.side == G1ServiceCommon.GestureSide.RIGHT) {
+                    activationEvents.emit(gesture)
+                    if(selectedSection.value != AppSection.ASSISTANT) {
+                        selectedSection.value = AppSection.ASSISTANT
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- decode tap and hold packets in the core layer, emitting a `G1Gesture` shared flow for each headset
- extend the service AIDL, implementation, and client wrapper to surface gesture events with an incrementing sequence
- plumb gesture flows through the hub repository and view-model, persisting the preferred activation gesture and switching to the assistant tab when it fires

## Testing
- ./gradlew build *(fails: Android SDK not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd913e96b48332a17885d430cf63c5