### PR TITLE
Add retry and HUD warnings for ChatGPT failures

### DIFF
--- a/hub/src/test/java/io/texne/g1/hub/ai/ChatGptRepositoryTest.kt
+++ b/hub/src/test/java/io/texne/g1/hub/ai/ChatGptRepositoryTest.kt
@@ -1,0 +1,104 @@
+package io.texne.g1.hub.ai
+
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.verify
+import java.io.IOException
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import okhttp3.Call
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+
+class ChatGptRepositoryTest {
+
+    @MockK
+    lateinit var preferences: ChatPreferences
+
+    @MockK
+    lateinit var httpClient: OkHttpClient
+
+    private lateinit var repository: ChatGptRepository
+
+    @BeforeTest
+    fun setUp() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        repository = ChatGptRepository(preferences, httpClient)
+        every { preferences.getApiKey() } returns "test-key"
+    }
+
+    @Test
+    fun `network error retried once then succeeds`() = runTest {
+        val failingCall = mockk<Call>(relaxed = true)
+        val succeedingCall = mockk<Call>(relaxed = true)
+
+        every { httpClient.newCall(any()) } returnsMany listOf(failingCall, succeedingCall)
+        every { failingCall.execute() } throws IOException("boom")
+        every { succeedingCall.execute() } returns successResponse("Hello world")
+
+        val persona = ChatPersona(
+            id = "test",
+            displayName = "Test",
+            description = "",
+            systemPrompt = ""
+        )
+        val result = repository.requestChatCompletion(
+            persona,
+            history = listOf(ChatGptRepository.ChatMessageData("user", "hi"))
+        )
+
+        assertTrue(result.isSuccess)
+        assertEquals("Hello world", result.getOrNull())
+        verify(exactly = 2) { httpClient.newCall(any()) }
+    }
+
+    @Test
+    fun `network error retried once then fails`() = runTest {
+        val firstCall = mockk<Call>(relaxed = true)
+        val secondCall = mockk<Call>(relaxed = true)
+
+        every { httpClient.newCall(any()) } returnsMany listOf(firstCall, secondCall)
+        every { firstCall.execute() } throws IOException("first")
+        every { secondCall.execute() } throws IOException("second")
+
+        val persona = ChatPersona(
+            id = "test",
+            displayName = "Test",
+            description = "",
+            systemPrompt = ""
+        )
+
+        val result = repository.requestChatCompletion(
+            persona,
+            history = listOf(ChatGptRepository.ChatMessageData("user", "hi"))
+        )
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is ChatGptRepository.ChatCompletionException.Network)
+        verify(exactly = 2) { httpClient.newCall(any()) }
+    }
+
+    private fun successResponse(content: String): Response {
+        val request = Request.Builder()
+            .url("https://api.openai.com/v1/chat/completions")
+            .build()
+        val body = """{"choices":[{"message":{"content":"$content"}}]}"""
+            .toResponseBody("application/json".toMediaType())
+        return Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(200)
+            .message("OK")
+            .body(body)
+            .build()
+    }
+}

--- a/hub/src/test/java/io/texne/g1/hub/ui/chat/ChatViewModelTest.kt
+++ b/hub/src/test/java/io/texne/g1/hub/ui/chat/ChatViewModelTest.kt
@@ -7,14 +7,17 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.texne.g1.hub.MainDispatcherRule
 import io.texne.g1.hub.ai.ChatGptRepository
+import io.texne.g1.hub.ai.ChatGptRepository.ChatCompletionException
 import io.texne.g1.hub.ai.ChatPersona
 import io.texne.g1.hub.model.Repository
+import java.io.IOException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class ChatViewModelTest {
 
@@ -71,5 +74,62 @@ class ChatViewModelTest {
         advanceUntilIdle()
 
         coVerify(exactly = 0) { serviceRepository.displayCenteredPageOnConnectedGlasses(any(), any()) }
+    }
+
+    @Test
+    fun `missing key failure displays warning on hud`() = runTest {
+        val viewModel = ChatViewModel(chatRepository, serviceRepository)
+
+        coEvery { chatRepository.requestChatCompletion(any(), any()) } returns Result.failure(
+            ChatCompletionException.MissingApiKey
+        )
+        coEvery { serviceRepository.displayCenteredOnConnectedGlasses(any(), any()) } returns true
+
+        viewModel.sendPrompt("hello")
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            serviceRepository.displayCenteredOnConnectedGlasses(listOf("⚠️ No ChatGPT key"), null)
+        }
+
+        assertEquals("⚠️ No ChatGPT key", viewModel.state.value.errorMessage)
+    }
+
+    @Test
+    fun `invalid key failure displays warning on hud`() = runTest {
+        val viewModel = ChatViewModel(chatRepository, serviceRepository)
+
+        coEvery { chatRepository.requestChatCompletion(any(), any()) } returns Result.failure(
+            ChatCompletionException.Http(code = 401, errorMessage = "Invalid key")
+        )
+        coEvery { serviceRepository.displayCenteredOnConnectedGlasses(any(), any()) } returns true
+
+        viewModel.sendPrompt("hello")
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            serviceRepository.displayCenteredOnConnectedGlasses(listOf("⚠️ No ChatGPT key"), null)
+        }
+
+        assertEquals("⚠️ No ChatGPT key", viewModel.state.value.errorMessage)
+    }
+
+    @Test
+    fun `network failure displays warning on hud`() = runTest {
+        val viewModel = ChatViewModel(chatRepository, serviceRepository)
+
+        coEvery { chatRepository.requestChatCompletion(any(), any()) } returns Result.failure(
+            ChatCompletionException.Network(IOException("boom"))
+        )
+        coEvery { serviceRepository.displayCenteredOnConnectedGlasses(any(), any()) } returns true
+
+        viewModel.sendPrompt("hello")
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            serviceRepository.displayCenteredOnConnectedGlasses(listOf("⚠️ Connection error"), null)
+        }
+
+        assertEquals("⚠️ Connection error", viewModel.state.value.errorMessage)
     }
 }


### PR DESCRIPTION
## Summary
- add typed ChatCompletionException and retry ChatGPT calls once on network errors
- surface missing or invalid key and connection warnings on the HUD and error card
- add unit coverage for HUD warnings and single retry behaviour

## Testing
- ./gradlew hub:test *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8c690bc88332892ad1d5e363fd01