### PR TITLE
Ensure G1 pairing uses unique token and add unit test

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -37,4 +37,6 @@ dependencies {
     implementation(libs.nordic.ble.ktx)
     implementation(libs.nordic.ble.common)
     implementation(libs.nordic.scanner)
+    testImplementation(libs.junit)
+    testImplementation(libs.mockk)
 }

--- a/core/src/test/java/io/texne/g1/basis/core/G1FindTest.kt
+++ b/core/src/test/java/io/texne/g1/basis/core/G1FindTest.kt
@@ -1,0 +1,60 @@
+package io.texne.g1.basis.core
+
+import android.bluetooth.BluetoothDevice
+import io.mockk.every
+import io.mockk.mockk
+import no.nordicsemi.android.support.v18.scanner.ScanResult
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class G1FindTest {
+
+    @Test
+    fun `pairs with shared suffix are emitted independently`() {
+        val foundAddresses = mutableListOf<String>()
+        val foundPairs = mutableMapOf<String, G1.Companion.FoundPair>()
+
+        val results = listOf(
+            fakeScanResult("AA:BB:CC:DD:EE:01", "Even G1_7_L_alpha"),
+            fakeScanResult("AA:BB:CC:DD:EE:02", "Even G1_7_R_alpha"),
+            fakeScanResult("AA:BB:CC:DD:EE:03", "Even G1_7_L_beta"),
+            fakeScanResult("AA:BB:CC:DD:EE:04", "Even G1_7_R_beta"),
+        )
+
+        val completed = G1.collectCompletePairs(results, foundAddresses, foundPairs)
+
+        assertEquals("Expected two completed pairs", 2, completed.size)
+        assertTrue("No partial pairs should remain", foundPairs.isEmpty())
+
+        val emittedNames = completed.map { pair ->
+            val leftName = pair.left?.device?.name
+            val rightName = pair.right?.device?.name
+            leftName to rightName
+        }.toSet()
+
+        val expectedNames = setOf(
+            "Even G1_7_L_alpha" to "Even G1_7_R_alpha",
+            "Even G1_7_L_beta" to "Even G1_7_R_beta",
+        )
+        assertEquals(expectedNames, emittedNames)
+        assertEquals(
+            listOf(
+                "AA:BB:CC:DD:EE:01",
+                "AA:BB:CC:DD:EE:02",
+                "AA:BB:CC:DD:EE:03",
+                "AA:BB:CC:DD:EE:04",
+            ),
+            foundAddresses
+        )
+    }
+
+    private fun fakeScanResult(address: String, name: String): ScanResult {
+        val device = mockk<BluetoothDevice>()
+        every { device.address } returns address
+        every { device.name } returns name
+        val scanResult = mockk<ScanResult>()
+        every { scanResult.device } returns device
+        return scanResult
+    }
+}


### PR DESCRIPTION
## Summary
- derive a unique pairing token from device names so left/right entries with matching suffixes stay isolated
- centralize the scan result aggregation logic and reuse it inside the BLE scan callback
- add junit/mockk test dependencies and a unit test covering simultaneous suffix-based pairs

## Testing
- ./gradlew :core:test *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce144faef8833288728868d2c5e164