### PR TITLE
Normalize asymmetric G1 pairing suffixes

### DIFF
--- a/core/src/test/java/io/texne/g1/basis/core/G1FindTest.kt
+++ b/core/src/test/java/io/texne/g1/basis/core/G1FindTest.kt
@@ -49,6 +49,43 @@ class G1FindTest {
         )
     }
 
+    @Test
+    fun `asymmetric suffix pairs normalize to same key`() {
+        val foundAddresses = mutableListOf<String>()
+        val foundPairs = mutableMapOf<String, G1.Companion.FoundPair>()
+
+        val results = listOf(
+            fakeScanResult("AA:BB:CC:DD:EE:10", "Even G1_7_L_CEOCDF"),
+            fakeScanResult("AA:BB:CC:DD:EE:11", "Even G1_7_R_1D7162"),
+            fakeScanResult("AA:BB:CC:DD:EE:12", "Even G1_7_L_unpaired"),
+            fakeScanResult("AA:BB:CC:DD:EE:13", "Even G1_7_R_different"),
+        )
+
+        val completed = G1.collectCompletePairs(results, foundAddresses, foundPairs)
+
+        assertEquals("Expected one completed pair", 1, completed.size)
+        val pair = completed.single()
+        assertEquals("Even G1_7_L_CEOCDF", pair.left?.device?.name)
+        assertEquals("Even G1_7_R_1D7162", pair.right?.device?.name)
+
+        assertEquals(
+            setOf("Even G1_7_unpaired", "Even G1_7_different"),
+            foundPairs.keys
+        )
+        assertEquals("Even G1_7_L_unpaired", foundPairs["Even G1_7_unpaired"]?.left?.device?.name)
+        assertEquals("Even G1_7_R_different", foundPairs["Even G1_7_different"]?.right?.device?.name)
+
+        assertEquals(
+            listOf(
+                "AA:BB:CC:DD:EE:10",
+                "AA:BB:CC:DD:EE:11",
+                "AA:BB:CC:DD:EE:12",
+                "AA:BB:CC:DD:EE:13",
+            ),
+            foundAddresses
+        )
+    }
+
     private fun fakeScanResult(address: String, name: String): ScanResult {
         val device = mockk<BluetoothDevice>()
         every { device.address } returns address


### PR DESCRIPTION
## Summary
- normalize G1 pairing tokens so left/right asymmetric suffix codes (e.g. CEOCDF vs 1D7162) collapse to a shared key
- add a regression test ensuring the canonicalized pair emits while other mismatched suffixes remain isolated

## Testing
- ./gradlew :core:test --console=plain *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce40d0ba448332a100f6fa8f20be90