### PR TITLE
Add automatic retry countdown for glasses connections

### DIFF
--- a/hub/src/main/java/io/texne/g1/hub/ui/ApplicationFrame.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/ApplicationFrame.kt
@@ -58,8 +58,11 @@ fun ApplicationFrame() {
                         scanning = state.scanning,
                         error = state.error,
                         nearbyGlasses = state.nearbyGlasses,
+                        retry = state.retry,
                         scan = { viewModel.scan() },
                         connect = { viewModel.connect(it) },
+                        cancelRetry = { viewModel.cancelRetry(it) },
+                        retryNow = { viewModel.retryNow(it) }
                     )
                 }
             }


### PR DESCRIPTION
## Summary
- detect disconnected/error glasses statuses and schedule coroutine countdown retries in the application view-model
- surface retry countdown state to the scanner UI and wire cancel/manual retry actions
- display retry progress in the scanner list and auto-trigger connection attempts when the timer expires

## Testing
- ./gradlew hub:lint *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce5a8408248332bb3d3f3d16009806