### PR TITLE
Surface per-side scan results and manual pairing UI

### DIFF
--- a/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/G1DiscoveredDevice.aidl
+++ b/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/G1DiscoveredDevice.aidl
@@ -1,0 +1,7 @@
+// G1DiscoveredDevice.aidl
+package io.texne.g1.basis.service.protocol;
+
+parcelable G1DiscoveredDevice {
+    String address;
+    String name;
+}

--- a/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/G1ServiceState.aidl
+++ b/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/G1ServiceState.aidl
@@ -3,6 +3,7 @@ package io.texne.g1.basis.service.protocol;
 
 import io.texne.g1.basis.service.protocol.G1Glasses;
 import io.texne.g1.basis.service.protocol.G1GestureEvent;
+import io.texne.g1.basis.service.protocol.G1DiscoveredDevice;
 
 parcelable G1ServiceState {
     const int READY = 1;
@@ -13,4 +14,6 @@ parcelable G1ServiceState {
     int status;
     G1Glasses[] glasses;
     G1GestureEvent gestureEvent;
+    G1DiscoveredDevice[] leftDevices;
+    G1DiscoveredDevice[] rightDevices;
 }

--- a/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/IG1Service.aidl
+++ b/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/IG1Service.aidl
@@ -7,7 +7,7 @@ import io.texne.g1.basis.service.protocol.OperationCallback;
 interface IG1Service {
     void observeState(ObserveStateCallback callback);
     void lookForGlasses();
-    void connectGlasses(String id, @nullable OperationCallback callback);
+    void connectDevices(String leftAddress, String rightAddress, @nullable OperationCallback callback);
     void disconnectGlasses(String id, @nullable OperationCallback callback);
     void displayTextPage(String id, in String[] page, @nullable OperationCallback callback);
     void stopDisplaying(String id, @nullable OperationCallback callback);

--- a/client/src/main/java/io/texne/g1/basis/client/G1ServiceClient.kt
+++ b/client/src/main/java/io/texne/g1/basis/client/G1ServiceClient.kt
@@ -65,7 +65,19 @@ class G1ServiceClient private constructor(context: Context): G1ServiceCommon<IG1
                                     else -> GlassesStatus.ERROR
                                 },
                                 batteryPercentage = it.batteryPercentage
-                            ) }
+                            ) },
+                            availableLeftDevices = newState.leftDevices?.map { device ->
+                                AvailableDevice(
+                                    address = device.address,
+                                    name = device.name
+                                )
+                            } ?: emptyList(),
+                            availableRightDevices = newState.rightDevices?.map { device ->
+                                AvailableDevice(
+                                    address = device.address,
+                                    name = device.name
+                                )
+                            } ?: emptyList()
                         )
                     }
                 }

--- a/client/src/main/java/io/texne/g1/basis/client/G1ServiceCommon.kt
+++ b/client/src/main/java/io/texne/g1/basis/client/G1ServiceCommon.kt
@@ -30,11 +30,18 @@ abstract class G1ServiceCommon<ServiceInterface> constructor(
         val batteryPercentage: Int
     )
 
+    data class AvailableDevice(
+        val address: String,
+        val name: String
+    )
+
     enum class ServiceStatus { READY, LOOKING, LOOKED, ERROR }
 
     data class State(
         val status: ServiceStatus,
-        val glasses: List<Glasses>
+        val glasses: List<Glasses>,
+        val availableLeftDevices: List<AvailableDevice> = emptyList(),
+        val availableRightDevices: List<AvailableDevice> = emptyList()
     )
 
     protected val writableState =

--- a/client/src/main/java/io/texne/g1/basis/client/G1ServiceManager.kt
+++ b/client/src/main/java/io/texne/g1/basis/client/G1ServiceManager.kt
@@ -87,7 +87,19 @@ class G1ServiceManager private constructor(context: Context): G1ServiceCommon<IG
                                     else -> GlassesStatus.ERROR
                                 },
                                 batteryPercentage = it.batteryPercentage
-                            ) }
+                            ) },
+                            availableLeftDevices = newState.leftDevices?.map { device ->
+                                AvailableDevice(
+                                    address = device.address,
+                                    name = device.name
+                                )
+                            } ?: emptyList(),
+                            availableRightDevices = newState.rightDevices?.map { device ->
+                                AvailableDevice(
+                                    address = device.address,
+                                    name = device.name
+                                )
+                            } ?: emptyList()
                         )
                     }
                 }
@@ -104,9 +116,10 @@ class G1ServiceManager private constructor(context: Context): G1ServiceCommon<IG
         service?.lookForGlasses()
     }
 
-    suspend fun connect(id: String) = suspendCoroutine<Boolean> { continuation ->
-        service?.connectGlasses(
-            id,
+    suspend fun connect(leftAddress: String, rightAddress: String) = suspendCoroutine<Boolean> { continuation ->
+        service?.connectDevices(
+            leftAddress,
+            rightAddress,
             object : io.texne.g1.basis.service.protocol.OperationCallback.Stub() {
                 override fun onResult(success: Boolean) {
                     continuation.resume(success)

--- a/core/src/main/java/io/texne/g1/basis/core/protocol.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/protocol.kt
@@ -72,13 +72,13 @@ internal fun hasFirstTwo(first: Byte, second: Byte): (ByteArray) -> Boolean = { 
 enum class IncomingPacketType(
     val label: String,
     val isType: (bytes: ByteArray) -> Boolean,
-    val factory: (type: IncomingPacketType, bytes: ByteArray) -> IncomingPacket?
+    val factory: IncomingPacketType.(bytes: ByteArray) -> IncomingPacket?
 ) {
-    EXIT("EXIT", hasFirst(0x18), { _, bytes -> ExitResponsePacket(bytes) }),
-    GLASSES_BATTERY_LEVEL("GLASSES_BATTERY_LEVEL", hasFirstTwo(0x2C, 0x66), { _, bytes -> BatteryLevelResponsePacket(bytes) }),
-    AI_RESULT_RECEIVED("AI_RESULT_RECEIVED", hasFirst(0x4E), { _, bytes -> SendTextResponsePacket(bytes) }),
-    GESTURE_TAP("GESTURE_TAP", hasFirst(0x29), { type, bytes -> GesturePacket(type, bytes, G1Gesture.Type.TAP) }),
-    GESTURE_HOLD("GESTURE_HOLD", hasFirst(0x2B), { type, bytes -> GesturePacket(type, bytes, G1Gesture.Type.HOLD) }),
+    EXIT("EXIT", hasFirst(0x18), { bytes -> ExitResponsePacket(bytes) }),
+    GLASSES_BATTERY_LEVEL("GLASSES_BATTERY_LEVEL", hasFirstTwo(0x2C, 0x66), { bytes -> BatteryLevelResponsePacket(bytes) }),
+    AI_RESULT_RECEIVED("AI_RESULT_RECEIVED", hasFirst(0x4E), { bytes -> SendTextResponsePacket(bytes) }),
+    GESTURE_TAP("GESTURE_TAP", hasFirst(0x29), { bytes -> GesturePacket(this, bytes, G1Gesture.Type.TAP) }),
+    GESTURE_HOLD("GESTURE_HOLD", hasFirst(0x2B), { bytes -> GesturePacket(this, bytes, G1Gesture.Type.HOLD) }),
 ;
     override fun toString() = label
 }
@@ -151,7 +151,7 @@ abstract class IncomingPacket(val type: IncomingPacketType, val bytes: ByteArray
     companion object {
         fun fromBytes(bytes: ByteArray): IncomingPacket? =
             IncomingPacketType.entries.firstOrNull { it.isType(bytes) }?.let { type ->
-                type.factory(type, bytes)
+                type.factory(bytes)
             }
     }
 }

--- a/core/src/test/java/io/texne/g1/basis/core/G1FindTest.kt
+++ b/core/src/test/java/io/texne/g1/basis/core/G1FindTest.kt
@@ -22,12 +22,12 @@ class G1FindTest {
             fakeScanResult("AA:BB:CC:DD:EE:04", "Even G1_7_R_beta"),
         )
 
-        val completed = G1.collectCompletePairs(results, foundAddresses, foundPairs)
+        val update = G1.collectScanUpdates(results, foundAddresses, foundPairs)
 
-        assertEquals("Expected two completed pairs", 2, completed.size)
+        assertEquals("Expected two completed pairs", 2, update.completedPairs.size)
         assertTrue("No partial pairs should remain", foundPairs.isEmpty())
 
-        val emittedNames = completed.map { pair ->
+        val emittedNames = update.completedPairs.map { pair ->
             val leftName = pair.left?.device?.name
             val rightName = pair.right?.device?.name
             leftName to rightName
@@ -47,6 +47,9 @@ class G1FindTest {
             ),
             foundAddresses
         )
+
+        assertEquals(2, update.newLeftDevices.size)
+        assertEquals(2, update.newRightDevices.size)
     }
 
     @Test
@@ -61,10 +64,10 @@ class G1FindTest {
             fakeScanResult("AA:BB:CC:DD:EE:13", "Even G1_7_R_different"),
         )
 
-        val completed = G1.collectCompletePairs(results, foundAddresses, foundPairs)
+        val update = G1.collectScanUpdates(results, foundAddresses, foundPairs)
 
-        assertEquals("Expected one completed pair", 1, completed.size)
-        val pair = completed.single()
+        assertEquals("Expected one completed pair", 1, update.completedPairs.size)
+        val pair = update.completedPairs.single()
         assertEquals("Even G1_7_L_CEOCDF", pair.left?.device?.name)
         assertEquals("Even G1_7_R_1D7162", pair.right?.device?.name)
 
@@ -84,6 +87,9 @@ class G1FindTest {
             ),
             foundAddresses
         )
+
+        assertEquals(2, update.newLeftDevices.size)
+        assertEquals(2, update.newRightDevices.size)
     }
 
     private fun fakeScanResult(address: String, name: String): ScanResult {

--- a/hub/src/main/java/io/texne/g1/hub/ui/ApplicationFrame.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/ApplicationFrame.kt
@@ -58,8 +58,14 @@ fun ApplicationFrame() {
                         scanning = state.scanning,
                         error = state.error,
                         nearbyGlasses = state.nearbyGlasses,
+                        availableLeftDevices = state.availableLeftDevices,
+                        availableRightDevices = state.availableRightDevices,
+                        selectedLeftAddress = state.selectedLeftDeviceAddress,
+                        selectedRightAddress = state.selectedRightDeviceAddress,
                         scan = { viewModel.scan() },
-                        connect = { viewModel.connect(it) },
+                        onSelectLeft = viewModel::selectLeftDevice,
+                        onSelectRight = viewModel::selectRightDevice,
+                        connectSelected = { viewModel.connectSelectedDevices() },
                     )
                 }
             }

--- a/hub/src/main/java/io/texne/g1/hub/ui/scanner/ScannerScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/scanner/ScannerScreen.kt
@@ -1,21 +1,21 @@
-import androidx.compose.animation.ExperimentalSharedTransitionApi
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
@@ -23,12 +23,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.texne.g1.basis.client.G1ServiceCommon
-import io.texne.g1.hub.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -36,8 +34,14 @@ fun ScannerScreen(
     scanning: Boolean,
     error: Boolean,
     nearbyGlasses: List<G1ServiceCommon.Glasses>?,
+    availableLeftDevices: List<G1ServiceCommon.AvailableDevice>,
+    availableRightDevices: List<G1ServiceCommon.AvailableDevice>,
+    selectedLeftAddress: String?,
+    selectedRightAddress: String?,
     scan: () -> Unit,
-    connect: (id: String) -> Unit
+    onSelectLeft: (String?) -> Unit,
+    onSelectRight: (String?) -> Unit,
+    connectSelected: () -> Unit,
 ) {
     val pullToRefreshState = rememberPullToRefreshState()
 
@@ -45,134 +49,146 @@ fun ScannerScreen(
         modifier = Modifier.fillMaxSize(),
         isRefreshing = scanning,
         onRefresh = scan,
-        state = pullToRefreshState,
+        state = pullToRefreshState
     ) {
-        LazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            verticalArrangement = if (
-                nearbyGlasses.isNullOrEmpty()
-            ) Arrangement.Center else Arrangement.spacedBy(32.dp)
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp, vertical = 24.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(24.dp)
         ) {
             when {
-                nearbyGlasses.isNullOrEmpty().not() -> {
-                    items(nearbyGlasses!!.size) {
-                        GlassesItem(
-                            nearbyGlasses[it],
-                            { connect(nearbyGlasses[it].id) }
-                        )
-                    }
-                }
-
-                scanning -> {
-                    item {
-                        Box(
-                            modifier = Modifier.fillMaxWidth(),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Text("Scanning for nearby glasses...")
-                        }
-                    }
-                }
-
-                error -> {
-                    item {
-                        Box(
-                            modifier = Modifier.fillMaxWidth(),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Text("An error ocurred. Please try again.")
-                        }
-                    }
-                }
-
-                nearbyGlasses != null -> {
-                    item {
-                        Box(
-                            modifier = Modifier.fillMaxWidth(),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Text("No glasses were found nearby.")
-                        }
-                    }
-                }
+                error -> StatusText("An error occurred. Please try again.")
+                scanning -> StatusText("Scanning for nearby glasses…")
+                availableLeftDevices.isEmpty() && availableRightDevices.isEmpty() ->
+                    StatusText("No devices were found nearby.")
             }
-        }
-    }
-}
 
-@OptIn(ExperimentalSharedTransitionApi::class)
-@Composable
-fun GlassesItem(
-    glasses: G1ServiceCommon.Glasses,
-    connect: () -> Unit
-) {
-    Box(
-        Modifier.fillMaxWidth()
-            .padding(horizontal = 16.dp)
-    ) {
-        Box(
-            Modifier.fillMaxWidth()
-                .background(Color.White, RoundedCornerShape(16.dp))
-        ) {
-            Column(
-                Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(2.5f)
-                    .padding(16.dp)
+            DeviceSelectionSection(
+                title = "Left devices",
+                devices = availableLeftDevices,
+                selectedAddress = selectedLeftAddress,
+                onSelect = onSelectLeft
+            )
+
+            DeviceSelectionSection(
+                title = "Right devices",
+                devices = availableRightDevices,
+                selectedAddress = selectedRightAddress,
+                onSelect = onSelectRight
+            )
+
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                enabled = selectedLeftAddress != null && selectedRightAddress != null,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color(6, 64, 43, 255),
+                    contentColor = Color.White
+                ),
+                onClick = connectSelected
             ) {
-                Row(
-                    Modifier.fillMaxWidth().weight(1f)
-                ) {
-                    Box(Modifier.weight(1f)) {
-                        Image(
-                            modifier = Modifier
-                                .padding(8.dp),
-                            painter = painterResource(R.drawable.glasses_a),
-                            contentDescription = "Image of glasses"
-                        )
-                    }
-                    Box(
-                        Modifier.weight(1f).fillMaxHeight().padding(8.dp),
-                        contentAlignment = Alignment.CenterEnd
-                    ) {
-                        when {
-                            glasses.status == G1ServiceCommon.GlassesStatus.CONNECTING || glasses.status == G1ServiceCommon.GlassesStatus.DISCONNECTING -> {
-                                CircularProgressIndicator(
-                                    color = Color.Black
-                                )
-                            }
+                Text("Connect selected devices")
+            }
 
-                            glasses.status != G1ServiceCommon.GlassesStatus.CONNECTED -> {
-                                Button(
-                                    colors = ButtonDefaults.buttonColors(
-                                        containerColor = Color(6, 64, 43, 255),
-                                        contentColor = Color.White
-                                    ),
-                                    onClick = { connect() }
-                                ) {
-                                    Text("CONNECT")
-                                }
-                            }
+            if (!nearbyGlasses.isNullOrEmpty()) {
+                DetectedPairsSection(nearbyGlasses)
+            }
+        }
+    }
+}
 
-                            else -> {
-                            }
-                        }
-                    }
+@Composable
+private fun StatusText(message: String) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant
+    ) {
+        Text(
+            text = message,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontSize = 14.sp
+        )
+    }
+}
+
+@Composable
+private fun DeviceSelectionSection(
+    title: String,
+    devices: List<G1ServiceCommon.AvailableDevice>,
+    selectedAddress: String?,
+    onSelect: (String?) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text(title, fontSize = 18.sp, fontWeight = FontWeight.Bold)
+        if (devices.isEmpty()) {
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(12.dp),
+                tonalElevation = 2.dp
+            ) {
+                Text(
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                    text = "No devices detected",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontSize = 14.sp
+                )
+            }
+        } else {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                devices.forEach { device ->
+                    val isSelected = device.address == selectedAddress
+                    DeviceSelectionItem(
+                        device = device,
+                        selected = isSelected,
+                        onClick = { onSelect(if (isSelected) null else device.address) }
+                    )
                 }
-                Row(
-                    Modifier.weight(1f).padding(horizontal = 8.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.Bottom
-                ) {
-                    Column(
-                        verticalArrangement = Arrangement.spacedBy((-8).dp)
-                    ) {
-                        Text(
-                            text = glasses.name,
-                            fontSize = 24.sp,
-                            color = Color.Black,
-                            fontWeight = FontWeight.Black
-                        )
-                        Text(glasses.id, fontSize = 10.sp, color = Color.Gray)
+            }
+        }
+    }
+}
+
+@Composable
+private fun DeviceSelectionItem(
+    device: G1ServiceCommon.AvailableDevice,
+    selected: Boolean,
+    onClick: () -> Unit
+) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(16.dp),
+        border = BorderStroke(1.dp, if (selected) Color(6, 64, 43, 255) else MaterialTheme.colorScheme.outlineVariant),
+        color = if (selected) Color(230, 244, 235) else MaterialTheme.colorScheme.surface
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
+            Text(device.name, fontSize = 16.sp, fontWeight = FontWeight.Medium)
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(device.address, fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+@Composable
+private fun DetectedPairsSection(glasses: List<G1ServiceCommon.Glasses>) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text("Detected pairs", fontSize = 18.sp, fontWeight = FontWeight.Bold)
+        glasses.forEach { pair ->
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(12.dp),
+                tonalElevation = 2.dp
+            ) {
+                Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
+                    Text(pair.name, fontSize = 16.sp, fontWeight = FontWeight.Medium)
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.SpaceBetween) {
+                        Text(pair.id, fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        Text(pair.status.label(), fontSize = 12.sp, fontWeight = FontWeight.Medium)
                     }
                 }
             }
@@ -180,3 +196,11 @@ fun GlassesItem(
     }
 }
 
+private fun G1ServiceCommon.GlassesStatus.label(): String = when (this) {
+    G1ServiceCommon.GlassesStatus.UNINITIALIZED -> "Uninitialized"
+    G1ServiceCommon.GlassesStatus.DISCONNECTED -> "Disconnected"
+    G1ServiceCommon.GlassesStatus.CONNECTING -> "Connecting"
+    G1ServiceCommon.GlassesStatus.CONNECTED -> "Connected"
+    G1ServiceCommon.GlassesStatus.DISCONNECTING -> "Disconnecting"
+    G1ServiceCommon.GlassesStatus.ERROR -> "Error"
+}


### PR DESCRIPTION
## Summary
- expose partial scan updates in the core scanner so callers can observe left/right device discoveries
- add per-side device tracking and a connectDevices entrypoint across the service/client layers
- rework the repository, view-model, and scanner UI to let users choose left/right units before connecting

## Testing
- ./gradlew test *(fails: Android SDK is not configured in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce5a850acc833282bc7bb64b45d3b2