### PR TITLE
Improve scanner error messaging

### DIFF
--- a/hub/src/main/java/io/texne/g1/hub/ui/ApplicationFrame.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/ApplicationFrame.kt
@@ -56,7 +56,7 @@ fun ApplicationFrame() {
                 } else {
                     ScannerScreen(
                         scanning = state.scanning,
-                        error = state.error,
+                        scannerPrompt = state.scannerPrompt,
                         nearbyGlasses = state.nearbyGlasses,
                         scan = { viewModel.scan() },
                         connect = { viewModel.connect(it) },

--- a/hub/src/main/java/io/texne/g1/hub/ui/scanner/ScannerScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/scanner/ScannerScreen.kt
@@ -24,17 +24,19 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.texne.g1.basis.client.G1ServiceCommon
 import io.texne.g1.hub.R
+import io.texne.g1.hub.ui.ScannerPrompt
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ScannerScreen(
     scanning: Boolean,
-    error: Boolean,
+    scannerPrompt: ScannerPrompt?,
     nearbyGlasses: List<G1ServiceCommon.Glasses>?,
     scan: () -> Unit,
     connect: (id: String) -> Unit
@@ -69,18 +71,24 @@ fun ScannerScreen(
                             modifier = Modifier.fillMaxWidth(),
                             contentAlignment = Alignment.Center
                         ) {
-                            Text("Scanning for nearby glasses...")
+                            Text(stringResource(id = R.string.scanner_status_scanning))
                         }
                     }
                 }
 
-                error -> {
+                scannerPrompt != null -> {
                     item {
                         Box(
                             modifier = Modifier.fillMaxWidth(),
                             contentAlignment = Alignment.Center
                         ) {
-                            Text("An error ocurred. Please try again.")
+                            val message = when (scannerPrompt) {
+                                ScannerPrompt.GlassesSideIssue ->
+                                    stringResource(id = R.string.scanner_error_glasses)
+                                ScannerPrompt.HubSideIssue ->
+                                    stringResource(id = R.string.scanner_error_hub)
+                            }
+                            Text(message)
                         }
                     }
                 }
@@ -91,7 +99,7 @@ fun ScannerScreen(
                             modifier = Modifier.fillMaxWidth(),
                             contentAlignment = Alignment.Center
                         ) {
-                            Text("No glasses were found nearby.")
+                            Text(stringResource(id = R.string.scanner_status_none_found))
                         }
                     }
                 }

--- a/hub/src/main/res/values/strings.xml
+++ b/hub/src/main/res/values/strings.xml
@@ -7,4 +7,8 @@
     <string name="settings_assistant_activation_option_double">Double tap</string>
     <string name="settings_assistant_activation_option_triple">Triple tap</string>
     <string name="settings_assistant_activation_option_hold">Tap and hold</string>
+    <string name="scanner_status_scanning">Scanning for nearby glasses…</string>
+    <string name="scanner_status_none_found">No glasses were found nearby.</string>
+    <string name="scanner_error_glasses">We couldn&#39;t reach your glasses. Power cycle them, move closer, then start another scan.</string>
+    <string name="scanner_error_hub">We couldn&#39;t start a scan from the hub. Toggle Bluetooth or restart the app before scanning again.</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a ScannerPrompt state that captures scanner failure scenarios
- update the scanner screen to render localized guidance based on the prompt
- define localized strings for scanner status and recovery copy

## Testing
- ./gradlew :hub:lint *(fails: Android SDK is not configured in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce5a9184ec83329d7330980b08d6ce