### PR TITLE
Add troubleshooting help panel to scanner

### DIFF
--- a/hub/src/main/java/io/texne/g1/hub/ui/ApplicationFrame.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/ApplicationFrame.kt
@@ -58,6 +58,9 @@ fun ApplicationFrame() {
                         scanning = state.scanning,
                         error = state.error,
                         nearbyGlasses = state.nearbyGlasses,
+                        showTroubleshooting = state.showTroubleshooting,
+                        onDismissTroubleshooting = viewModel::dismissTroubleshooting,
+                        onRequestTroubleshooting = viewModel::requestTroubleshooting,
                         scan = { viewModel.scan() },
                         connect = { viewModel.connect(it) },
                     )

--- a/hub/src/main/java/io/texne/g1/hub/ui/scanner/ScannerScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/scanner/ScannerScreen.kt
@@ -1,22 +1,31 @@
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
@@ -24,6 +33,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -36,66 +46,109 @@ fun ScannerScreen(
     scanning: Boolean,
     error: Boolean,
     nearbyGlasses: List<G1ServiceCommon.Glasses>?,
+    showTroubleshooting: Boolean,
+    onDismissTroubleshooting: () -> Unit,
+    onRequestTroubleshooting: () -> Unit,
     scan: () -> Unit,
     connect: (id: String) -> Unit
 ) {
     val pullToRefreshState = rememberPullToRefreshState()
 
-    PullToRefreshBox(
-        modifier = Modifier.fillMaxSize(),
-        isRefreshing = scanning,
-        onRefresh = scan,
-        state = pullToRefreshState,
-    ) {
-        LazyColumn(
+    Box(modifier = Modifier.fillMaxSize()) {
+        PullToRefreshBox(
             modifier = Modifier.fillMaxSize(),
-            verticalArrangement = if (
-                nearbyGlasses.isNullOrEmpty()
-            ) Arrangement.Center else Arrangement.spacedBy(32.dp)
+            isRefreshing = scanning,
+            onRefresh = scan,
+            state = pullToRefreshState,
         ) {
-            when {
-                nearbyGlasses.isNullOrEmpty().not() -> {
-                    items(nearbyGlasses!!.size) {
-                        GlassesItem(
-                            nearbyGlasses[it],
-                            { connect(nearbyGlasses[it].id) }
-                        )
-                    }
-                }
-
-                scanning -> {
-                    item {
-                        Box(
-                            modifier = Modifier.fillMaxWidth(),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Text("Scanning for nearby glasses...")
+            val isEmpty = nearbyGlasses.isNullOrEmpty()
+            val bottomPadding = if (showTroubleshooting) 240.dp else 112.dp
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = if (isEmpty) Arrangement.Center else Arrangement.spacedBy(32.dp),
+                contentPadding = PaddingValues(bottom = if (isEmpty) 0.dp else bottomPadding)
+            ) {
+                when {
+                    nearbyGlasses.isNullOrEmpty().not() -> {
+                        items(nearbyGlasses!!, key = { it.id }) { glasses ->
+                            GlassesItem(
+                                glasses,
+                                { connect(glasses.id) }
+                            )
                         }
                     }
-                }
 
-                error -> {
-                    item {
-                        Box(
-                            modifier = Modifier.fillMaxWidth(),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Text("An error ocurred. Please try again.")
+                    scanning -> {
+                        item {
+                            Box(
+                                modifier = Modifier.fillMaxWidth(),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text(stringResource(R.string.scanner_scanning_message))
+                            }
                         }
                     }
-                }
 
-                nearbyGlasses != null -> {
-                    item {
-                        Box(
-                            modifier = Modifier.fillMaxWidth(),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Text("No glasses were found nearby.")
+                    error -> {
+                        item {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 24.dp),
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                verticalArrangement = Arrangement.spacedBy(12.dp)
+                            ) {
+                                Text(stringResource(R.string.scanner_error_message))
+                                TextButton(onClick = onRequestTroubleshooting) {
+                                    Text(stringResource(R.string.scanner_help_button))
+                                }
+                            }
+                        }
+                    }
+
+                    nearbyGlasses != null -> {
+                        item {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 24.dp),
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                verticalArrangement = Arrangement.spacedBy(12.dp)
+                            ) {
+                                Text(stringResource(R.string.scanner_empty_message))
+                                TextButton(onClick = onRequestTroubleshooting) {
+                                    Text(stringResource(R.string.scanner_help_button))
+                                }
+                            }
                         }
                     }
                 }
             }
+        }
+
+        if (!showTroubleshooting) {
+            FilledTonalButton(
+                onClick = onRequestTroubleshooting,
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(24.dp)
+            ) {
+                Text(stringResource(R.string.scanner_help_button))
+            }
+        }
+
+        AnimatedVisibility(
+            visible = showTroubleshooting,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(horizontal = 16.dp, vertical = 24.dp),
+            enter = slideInVertically { it } + fadeIn(),
+            exit = slideOutVertically { it } + fadeOut()
+        ) {
+            TroubleshootingPanel(
+                modifier = Modifier.fillMaxWidth(),
+                onDismiss = onDismissTroubleshooting
+            )
         }
     }
 }

--- a/hub/src/main/java/io/texne/g1/hub/ui/scanner/TroubleshootingPanel.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/scanner/TroubleshootingPanel.kt
@@ -1,0 +1,123 @@
+package io.texne.g1.hub.ui.scanner
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringArrayResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import io.texne.g1.hub.R
+
+@Composable
+fun TroubleshootingPanel(
+    modifier: Modifier = Modifier,
+    onDismiss: () -> Unit,
+    steps: List<String> = stringArrayResource(R.array.scanner_troubleshooting_steps).toList(),
+) {
+    val title = stringResource(R.string.scanner_troubleshooting_title)
+    val subtitle = stringResource(R.string.scanner_troubleshooting_subtitle)
+    val dismissLabel = stringResource(R.string.scanner_troubleshooting_dismiss)
+
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(24.dp),
+        tonalElevation = 8.dp,
+        shadowElevation = 12.dp,
+        color = MaterialTheme.colorScheme.surface,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f)
+                )
+                IconButton(onClick = onDismiss) {
+                    Icon(
+                        imageVector = Icons.Filled.Close,
+                        contentDescription = dismissLabel
+                    )
+                }
+            }
+
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                steps.forEachIndexed { index, step ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                        verticalAlignment = Alignment.Top
+                    ) {
+                        Surface(
+                            shape = CircleShape,
+                            color = MaterialTheme.colorScheme.primaryContainer,
+                            contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                        ) {
+                            Text(
+                                text = (index + 1).toString(),
+                                style = MaterialTheme.typography.labelLarge,
+                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
+                            )
+                        }
+
+                        Text(
+                            text = step,
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End
+            ) {
+                FilledTonalButton(onClick = onDismiss) {
+                    Text(text = dismissLabel)
+                }
+            }
+        }
+    }
+}

--- a/hub/src/main/res/values/strings.xml
+++ b/hub/src/main/res/values/strings.xml
@@ -7,4 +7,20 @@
     <string name="settings_assistant_activation_option_double">Double tap</string>
     <string name="settings_assistant_activation_option_triple">Triple tap</string>
     <string name="settings_assistant_activation_option_hold">Tap and hold</string>
+    <string name="scanner_scanning_message">Scanning for nearby glasses...</string>
+    <string name="scanner_error_message">We couldn't pair with your glasses. Try again or review the tips below.</string>
+    <string name="scanner_empty_message">No glasses were found nearby.</string>
+    <string name="scanner_help_button">Need help pairing?</string>
+    <string name="scanner_troubleshooting_title">Having trouble pairing?</string>
+    <string name="scanner_troubleshooting_subtitle">Try these steps to get connected.</string>
+    <string name="scanner_troubleshooting_dismiss">Got it</string>
+    <string-array name="scanner_troubleshooting_steps">
+        <item>Make sure your glasses are turned on.</item>
+        <item>Charge the glasses for at least 10 minutes before pairing.</item>
+        <item>Enable Bluetooth on your phone and keep it nearby.</item>
+        <item>Ensure the G1 Hub app has the required permissions.</item>
+        <item>Hold the glasses power button until the status light pulses.</item>
+        <item>Restart your glasses and your phone's Bluetooth.</item>
+        <item>Run a new scan from the G1 Hub app.</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
## Summary
- add a reusable troubleshooting panel component with localized guidance
- surface panel state in the application view model so it can be triggered on failures or by request
- integrate the panel with the scanner screen, including help affordances and updated copy

## Testing
- ./gradlew :hub:assembleDebug *(fails: Android SDK is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce5a92b2c48332af4d40664a430570