### PR TITLE
Add location and BLE scan permissions to service manifest

### DIFF
--- a/service/src/main/AndroidManifest.xml
+++ b/service/src/main/AndroidManifest.xml
@@ -2,8 +2,13 @@
 <manifest xmlns:tools="http://schemas.android.com/tools"
     xmlns:android="http://schemas.android.com/apk/res/android">
     <permission android:name="io.texne.g1.basis.permission.CONNECT_TO_SERVICE"/>
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <application>
         <service


### PR DESCRIPTION
## Summary
- add the ACCESS_FINE_LOCATION permission to the service manifest so the service can request precise location when needed
- declare the BLE permissions in the service manifest, ensuring BLUETOOTH_SCAN retains the neverForLocation flag for Android 12+

## Testing
- not run (manifest change)


------
https://chatgpt.com/codex/tasks/task_e_68ce66b0a2fc8332bdbefd42cc38774b