### PR TITLE
Improve formatted text display helpers

### DIFF
--- a/client/src/main/java/io/texne/g1/basis/client/G1ServiceClient.kt
+++ b/client/src/main/java/io/texne/g1/basis/client/G1ServiceClient.kt
@@ -98,7 +98,7 @@ class G1ServiceClient private constructor(context: Context): G1ServiceCommon<IG1
     }
 
 
-    override suspend fun displayTextPage(id: String, page: List<String>) =
+    override suspend fun sendTextPage(id: String, page: List<String>) =
         suspendCoroutine<Boolean> { continuation ->
             service?.displayTextPage(
                 id,

--- a/client/src/main/java/io/texne/g1/basis/client/G1ServiceManager.kt
+++ b/client/src/main/java/io/texne/g1/basis/client/G1ServiceManager.kt
@@ -139,7 +139,7 @@ class G1ServiceManager private constructor(context: Context): G1ServiceCommon<IG
         service?.disconnectGlasses(id, null)
     }
 
-    override suspend fun displayTextPage(id: String, page: List<String>) =
+    override suspend fun sendTextPage(id: String, page: List<String>) =
         suspendCoroutine<Boolean> { continuation ->
             service?.displayTextPage(
                 id,


### PR DESCRIPTION
## Summary
- validate text pages centrally and expose helpers for timed and formatted display flows
- render formatted pages with horizontal and vertical alignment while keeping within device limits
- update service clients to use the new sendTextPage hook for validated requests

## Testing
- ./gradlew test *(fails: SDK location not found in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce763e1a788332b80a73d79d7c39a1