### PR TITLE
Add telemetry UI, auto-connect feedback, and rssi reporting

### DIFF
--- a/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/G1Glasses.aidl
+++ b/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/G1Glasses.aidl
@@ -17,4 +17,6 @@ parcelable G1Glasses {
     int rightConnectionState;
     int leftBatteryPercentage;
     int rightBatteryPercentage;
+    int signalStrength;
+    int rssi;
 }

--- a/aidl/src/main/java/io/texne/g1/basis/service/protocol/TelemetryDefaults.kt
+++ b/aidl/src/main/java/io/texne/g1/basis/service/protocol/TelemetryDefaults.kt
@@ -1,0 +1,7 @@
+package io.texne.g1.basis.service.protocol
+
+/**
+ * Shared default values for optional telemetry reported by the service.
+ */
+const val SIGNAL_STRENGTH_UNKNOWN = -1
+const val RSSI_UNKNOWN = Int.MIN_VALUE

--- a/client/src/main/java/io/texne/g1/basis/client/G1ServiceClient.kt
+++ b/client/src/main/java/io/texne/g1/basis/client/G1ServiceClient.kt
@@ -84,7 +84,9 @@ class G1ServiceClient private constructor(context: Context): G1ServiceCommon<IG1
                                         else -> GlassesStatus.ERROR
                                     },
                                     leftBatteryPercentage = glass.leftBatteryPercentage,
-                                    rightBatteryPercentage = glass.rightBatteryPercentage
+                                    rightBatteryPercentage = glass.rightBatteryPercentage,
+                                    signalStrength = glass.signalStrength,
+                                    rssi = glass.rssi
                                 )
                             }
                         )

--- a/client/src/main/java/io/texne/g1/basis/client/G1ServiceCommon.kt
+++ b/client/src/main/java/io/texne/g1/basis/client/G1ServiceCommon.kt
@@ -2,6 +2,8 @@ package io.texne.g1.basis.client
 
 import android.content.Context
 import android.content.ServiceConnection
+import io.texne.g1.basis.service.protocol.RSSI_UNKNOWN
+import io.texne.g1.basis.service.protocol.SIGNAL_STRENGTH_UNKNOWN
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -27,7 +29,9 @@ abstract class G1ServiceCommon<ServiceInterface> constructor(
         val leftStatus: GlassesStatus,
         val rightStatus: GlassesStatus,
         val leftBatteryPercentage: Int,
-        val rightBatteryPercentage: Int
+        val rightBatteryPercentage: Int,
+        val signalStrength: Int = SIGNAL_STRENGTH_UNKNOWN,
+        val rssi: Int = RSSI_UNKNOWN
     )
 
     enum class ServiceStatus { READY, LOOKING, LOOKED, ERROR }

--- a/client/src/main/java/io/texne/g1/basis/client/G1ServiceManager.kt
+++ b/client/src/main/java/io/texne/g1/basis/client/G1ServiceManager.kt
@@ -106,7 +106,9 @@ class G1ServiceManager private constructor(context: Context): G1ServiceCommon<IG
                                         else -> GlassesStatus.ERROR
                                     },
                                     leftBatteryPercentage = glass.leftBatteryPercentage,
-                                    rightBatteryPercentage = glass.rightBatteryPercentage
+                                    rightBatteryPercentage = glass.rightBatteryPercentage,
+                                    signalStrength = glass.signalStrength,
+                                    rssi = glass.rssi
                                 )
                             }
                         )

--- a/core/src/main/java/io/texne/g1/basis/core/G1.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/G1.kt
@@ -29,6 +29,7 @@ import no.nordicsemi.android.support.v18.scanner.ScanCallback
 import no.nordicsemi.android.support.v18.scanner.ScanResult
 import no.nordicsemi.android.support.v18.scanner.ScanSettings
 import kotlin.time.Duration
+import kotlin.math.roundToInt
 
 @OptIn(DelicateCoroutinesApi::class)
 internal fun <T1, T2, R> StateFlow<T1>.combineState(
@@ -229,6 +230,25 @@ class G1 {
         left.sendRequest(ExitRequestPacket())
         right.sendRequest(ExitRequestPacket())
         return true
+    }
+
+    fun initialAverageRssi(): Int? {
+        val values = listOfNotNull(left.rssi, right.rssi)
+        if (values.isEmpty()) {
+            return null
+        }
+        val average = values.sum().toDouble() / values.size.toDouble()
+        return average.roundToInt()
+    }
+
+    fun initialSignalStrength(): Int? = initialAverageRssi()?.let { rssi ->
+        when {
+            rssi >= -50 -> 4
+            rssi >= -60 -> 3
+            rssi >= -70 -> 2
+            rssi >= -80 -> 1
+            else -> 0
+        }
     }
 
     // find devices --------------------------------------------------------------------------------

--- a/core/src/main/java/io/texne/g1/basis/core/G1Device.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/G1Device.kt
@@ -28,6 +28,7 @@ internal class G1Device(
     @SuppressLint("MissingPermission")
     val name = scanResult.device.name
     val address = scanResult.device.address
+    val rssi: Int? = scanResult.rssi.takeIf { it != 0 }
 
     // state flow ----------------------------------------------------------------------------------
 

--- a/core/src/test/java/io/texne/g1/basis/core/G1FindTest.kt
+++ b/core/src/test/java/io/texne/g1/basis/core/G1FindTest.kt
@@ -51,6 +51,36 @@ class G1FindTest {
     }
 
     @Test
+    fun `pairs without suffix fallback to address for identifiers`() {
+        val foundAddresses = mutableListOf<String>()
+        val foundPairs = mutableMapOf<String, G1.Companion.FoundPair>()
+
+        val results = listOf(
+            fakeScanResult("AA:BB:CC:DD:10:01", "Even G1_7_L"),
+            fakeScanResult("AA:BB:CC:DD:10:02", "Even G1_7_R"),
+            fakeScanResult("AA:BB:CC:DD:10:03", "Even G1_7_L"),
+            fakeScanResult("AA:BB:CC:DD:10:04", "Even G1_7_R"),
+        )
+
+        val completed = G1.collectCompletePairs(results, foundAddresses, foundPairs)
+
+        assertEquals("Expected two completed pairs", 2, completed.size)
+        assertTrue("No partial pairs should remain", foundPairs.isEmpty())
+
+        val identifiers = completed.map { it.identifier }.toSet()
+        assertEquals("Pairs should have unique identifiers", 2, identifiers.size)
+        assertEquals(
+            listOf(
+                "AA:BB:CC:DD:10:01",
+                "AA:BB:CC:DD:10:02",
+                "AA:BB:CC:DD:10:03",
+                "AA:BB:CC:DD:10:04",
+            ),
+            foundAddresses
+        )
+    }
+
+    @Test
     fun `devices with different suffixes remain partial`() {
         val foundAddresses = mutableListOf<String>()
         val foundPairs = mutableMapOf<String, G1.Companion.FoundPair>()

--- a/hub/build.gradle.kts
+++ b/hub/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
     implementation(libs.hilt.navigation.compose)
     implementation(project(":service"))
     implementation(project(":client"))
+    implementation(project(":aidl"))
     implementation(libs.androidx.security.crypto)
     implementation(libs.okhttp)
     implementation(libs.okhttp.logging)

--- a/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
+++ b/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
@@ -8,6 +8,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import dagger.hilt.android.AndroidEntryPoint
 import io.texne.g1.hub.model.Repository
@@ -28,9 +31,13 @@ class MainActivity: ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             G1HubTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
+                val snackbarHostState = remember { SnackbarHostState() }
+                Scaffold(
+                    modifier = Modifier.fillMaxSize(),
+                    snackbarHost = { SnackbarHost(snackbarHostState) }
+                ) { innerPadding ->
                     Box(Modifier.padding(innerPadding).fillMaxSize()) {
-                        ApplicationFrame()
+                        ApplicationFrame(snackbarHostState)
                     }
                 }
             }

--- a/hub/src/main/java/io/texne/g1/hub/model/Repository.kt
+++ b/hub/src/main/java/io/texne/g1/hub/model/Repository.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.texne.g1.basis.client.G1ServiceCommon
 import io.texne.g1.basis.client.G1ServiceManager
+import io.texne.g1.basis.service.protocol.RSSI_UNKNOWN
+import io.texne.g1.basis.service.protocol.SIGNAL_STRENGTH_UNKNOWN
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
@@ -33,7 +35,9 @@ class Repository @Inject constructor(
         val status: G1ServiceCommon.GlassesStatus,
         val batteryPercentage: Int,
         val left: EyeSnapshot,
-        val right: EyeSnapshot
+        val right: EyeSnapshot,
+        val signalStrength: Int?,
+        val rssi: Int?
     )
 
     data class ServiceSnapshot(
@@ -192,6 +196,8 @@ class Repository @Inject constructor(
         right = EyeSnapshot(
             status = rightStatus,
             batteryPercentage = rightBatteryPercentage
-        )
+        ),
+        signalStrength = signalStrength.takeIf { it != SIGNAL_STRENGTH_UNKNOWN },
+        rssi = rssi.takeIf { it != RSSI_UNKNOWN }
     )
 }

--- a/hub/src/main/java/io/texne/g1/hub/ui/telemetry/TelemetryScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/telemetry/TelemetryScreen.kt
@@ -1,0 +1,114 @@
+package io.texne.g1.hub.ui.telemetry
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.texne.g1.basis.client.G1ServiceCommon
+import io.texne.g1.hub.ui.ApplicationViewModel
+
+@Composable
+fun TelemetryScreen(
+    entries: List<ApplicationViewModel.TelemetryEntry>,
+    onDisconnect: (String) -> Unit
+) {
+    if (entries.isEmpty()) {
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text("Telemetry will appear after scanning begins.", color = Color.Gray)
+        }
+        return
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        items(entries, key = { it.id }) { entry ->
+            TelemetryCard(entry = entry, onDisconnect = onDisconnect)
+        }
+    }
+}
+
+@Composable
+private fun TelemetryCard(
+    entry: ApplicationViewModel.TelemetryEntry,
+    onDisconnect: (String) -> Unit
+) {
+    Box(Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(Color.White, RoundedCornerShape(16.dp))
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(Modifier.weight(1f)) {
+                    Text(entry.name, fontSize = 20.sp, fontWeight = FontWeight.Bold, color = Color.Black)
+                    Text(entry.id, fontSize = 11.sp, color = Color.Gray)
+                }
+                if (entry.status == G1ServiceCommon.GlassesStatus.CONNECTED) {
+                    Button(
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = Color(169, 11, 11, 255),
+                            contentColor = Color.White
+                        ),
+                        onClick = { onDisconnect(entry.id) }
+                    ) {
+                        Text("DISCONNECT")
+                    }
+                }
+            }
+
+            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                Text("Status • ${statusLabel(entry.status)}", color = Color.Black)
+                Text("Signal • ${signalLabel(entry.signalStrength)}", color = Color.Black)
+                Text("RSSI • ${rssiLabel(entry.rssi)}", color = Color.Black)
+                Text("Retry attempts • ${entry.retryCount}", color = Color.Black)
+            }
+        }
+    }
+}
+
+private fun statusLabel(status: G1ServiceCommon.GlassesStatus): String = when (status) {
+    G1ServiceCommon.GlassesStatus.UNINITIALIZED -> "Waiting"
+    G1ServiceCommon.GlassesStatus.DISCONNECTED -> "Disconnected"
+    G1ServiceCommon.GlassesStatus.CONNECTING -> "Connecting"
+    G1ServiceCommon.GlassesStatus.CONNECTED -> "Connected"
+    G1ServiceCommon.GlassesStatus.DISCONNECTING -> "Disconnecting"
+    G1ServiceCommon.GlassesStatus.ERROR -> "Error"
+}
+
+private fun signalLabel(strength: Int?): String = when (strength) {
+    null -> "Unknown"
+    4 -> "Excellent (4/4)"
+    3 -> "Good (3/4)"
+    2 -> "Fair (2/4)"
+    1 -> "Weak (1/4)"
+    0 -> "Very weak (0/4)"
+    else -> "Unknown"
+}
+
+private fun rssiLabel(rssi: Int?): String = rssi?.let { "$it dBm" } ?: "—"

--- a/hub/src/test/java/io/texne/g1/hub/model/ProtocolConstantsTest.kt
+++ b/hub/src/test/java/io/texne/g1/hub/model/ProtocolConstantsTest.kt
@@ -1,0 +1,14 @@
+package io.texne.g1.hub.model
+
+import io.texne.g1.basis.service.protocol.RSSI_UNKNOWN
+import io.texne.g1.basis.service.protocol.SIGNAL_STRENGTH_UNKNOWN
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ProtocolConstantsTest {
+    @Test
+    fun `protocol constants are accessible from hub`() {
+        assertEquals(-1, SIGNAL_STRENGTH_UNKNOWN)
+        assertEquals(Int.MIN_VALUE, RSSI_UNKNOWN)
+    }
+}

--- a/service/src/main/java/io/texne/g1/basis/service/G1Service.kt
+++ b/service/src/main/java/io/texne/g1/basis/service/G1Service.kt
@@ -30,6 +30,8 @@ import io.texne.g1.basis.service.protocol.G1ServiceState
 import io.texne.g1.basis.service.protocol.G1GestureEvent
 import io.texne.g1.basis.service.protocol.IG1Service
 import io.texne.g1.basis.service.protocol.IG1ServiceClient
+import io.texne.g1.basis.service.protocol.SIGNAL_STRENGTH_UNKNOWN
+import io.texne.g1.basis.service.protocol.RSSI_UNKNOWN
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -93,6 +95,8 @@ private fun G1Service.InternalGlasses.toGlasses(): G1Glasses {
     glasses.rightConnectionState = this.rightConnectionState.toInt()
     glasses.leftBatteryPercentage = this.leftBatteryPercentage ?: -1
     glasses.rightBatteryPercentage = this.rightBatteryPercentage ?: -1
+    glasses.signalStrength = this.signalStrength ?: SIGNAL_STRENGTH_UNKNOWN
+    glasses.rssi = this.rssi ?: RSSI_UNKNOWN
     return glasses
 }
 
@@ -130,6 +134,8 @@ class G1Service: Service() {
         val rightConnectionState: G1.ConnectionState,
         val leftBatteryPercentage: Int?,
         val rightBatteryPercentage: Int?,
+        val signalStrength: Int?,
+        val rssi: Int?,
         val g1: G1
     )
     internal data class InternalState(
@@ -314,6 +320,8 @@ class G1Service: Service() {
                                                     rightConnectionState = glassesState.rightConnectionState,
                                                     leftBatteryPercentage = glassesState.leftBatteryPercentage,
                                                     rightBatteryPercentage = glassesState.rightBatteryPercentage,
+                                                    signalStrength = found.initialSignalStrength(),
+                                                    rssi = found.initialAverageRssi(),
                                                     g1 = found
                                                 )
                                             )
@@ -338,6 +346,8 @@ class G1Service: Service() {
                                                                 rightConnectionState = glassesState.rightConnectionState,
                                                                 leftBatteryPercentage = glassesState.leftBatteryPercentage,
                                                                 rightBatteryPercentage = glassesState.rightBatteryPercentage,
+                                                                signalStrength = it.value.signalStrength,
+                                                                rssi = it.value.rssi,
                                                                 g1 = it.value.g1
                                                             )
                                                         )


### PR DESCRIPTION
## Summary
- extend the service protocol with signal strength and RSSI defaults and propagate them through the client/repository stack
- expose service status and auto-connect notifications in the view model while adding telemetry and status UI (including disconnect controls)
- cover address-suffix pairing logic with an additional unit test

## Testing
- `./gradlew test` *(fails: Android SDK location not configured in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce7bace73c8332a5b8a70a153be0bb