### PR TITLE
Fix pairing identifier for side-only device names

### DIFF
--- a/core/src/main/java/io/texne/g1/basis/core/G1.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/G1.kt
@@ -273,20 +273,18 @@ class G1 {
                 return null
             }
 
-            val prefixSegments = segments.take(sideIndex)
-            val suffixSegments = segments.drop(sideIndex + 1)
+            val prefixSegments = segments.take(sideIndex).filter { it.isNotEmpty() }
+            val suffixSegments = segments.drop(sideIndex + 1).filter { it.isNotEmpty() }
 
-            val identifierSuffix = if (suffixSegments.isNotEmpty()) {
-                suffixSegments.joinToString("_")
-            } else {
-                result.device.address.replace(":", "").takeLast(6)
+            val prefix = prefixSegments.joinToString("_").ifEmpty { null }
+            val suffix = suffixSegments.joinToString("_").ifEmpty { null }
+
+            return when {
+                prefix != null && suffix != null -> "${prefix}_${suffix}"
+                prefix != null -> prefix
+                suffix != null -> suffix
+                else -> result.device.address.replace(":", "")
             }
-
-            if (identifierSuffix.isEmpty()) {
-                return null
-            }
-
-            return (prefixSegments + identifierSuffix).joinToString("_")
         }
 
         private fun String.hasSideToken(side: String): Boolean =

--- a/core/src/test/java/io/texne/g1/basis/core/G1FindTest.kt
+++ b/core/src/test/java/io/texne/g1/basis/core/G1FindTest.kt
@@ -51,7 +51,7 @@ class G1FindTest {
     }
 
     @Test
-    fun `pairs without suffix fallback to address for identifiers`() {
+    fun `pairs without suffix share base identifier`() {
         val foundAddresses = mutableListOf<String>()
         val foundPairs = mutableMapOf<String, G1.Companion.FoundPair>()
 
@@ -67,14 +67,38 @@ class G1FindTest {
         assertEquals("Expected two completed pairs", 2, completed.size)
         assertTrue("No partial pairs should remain", foundPairs.isEmpty())
 
-        val identifiers = completed.map { it.identifier }.toSet()
-        assertEquals("Pairs should have unique identifiers", 2, identifiers.size)
+        val identifiers = completed.map { it.identifier }
+        assertEquals(listOf("Even G1_7", "Even G1_7"), identifiers)
         assertEquals(
             listOf(
                 "AA:BB:CC:DD:10:01",
                 "AA:BB:CC:DD:10:02",
                 "AA:BB:CC:DD:10:03",
                 "AA:BB:CC:DD:10:04",
+            ),
+            foundAddresses
+        )
+    }
+
+    @Test
+    fun `pairs without numeric segment are grouped`() {
+        val foundAddresses = mutableListOf<String>()
+        val foundPairs = mutableMapOf<String, G1.Companion.FoundPair>()
+
+        val results = listOf(
+            fakeScanResult("AA:BB:CC:00:01", "Even G1_L"),
+            fakeScanResult("AA:BB:CC:00:02", "Even G1_R"),
+        )
+
+        val completed = G1.collectCompletePairs(results, foundAddresses, foundPairs)
+
+        assertEquals(1, completed.size)
+        assertTrue(foundPairs.isEmpty())
+        assertEquals("Even G1", completed.first().identifier)
+        assertEquals(
+            listOf(
+                "AA:BB:CC:00:01",
+                "AA:BB:CC:00:02",
             ),
             foundAddresses
         )


### PR DESCRIPTION
## Summary
- normalize pairing identifiers to use the shared base name when no suffix is present
- update and extend pairing tests to cover side-only device names

## Testing
- ./gradlew :core:test *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce8d27e2fc8332b73cfd5c124f89b2