### PR TITLE
Align pairing token grouping for suffix-less device names

### DIFF
--- a/client/src/main/java/io/texne/g1/basis/client/G1ServiceClient.kt
+++ b/client/src/main/java/io/texne/g1/basis/client/G1ServiceClient.kt
@@ -192,19 +192,25 @@ class G1ServiceClient private constructor(context: Context): G1ServiceCommon<IG1
             return null
         }
 
-        val prefixSegments = segments.take(sideIndex)
-        val suffixSegments = segments.drop(sideIndex + 1)
-        val identifierSuffix = if (suffixSegments.isNotEmpty()) {
-            suffixSegments.joinToString("_")
-        } else {
-            address.replace(":", "").takeLast(6)
+        val prefixSegments = segments.take(sideIndex).filter { it.isNotEmpty() }
+        val suffixSegments = segments.drop(sideIndex + 1).filter { it.isNotEmpty() }
+
+        if (suffixSegments.isNotEmpty()) {
+            val identifierSuffix = suffixSegments.joinToString("_")
+            val identifierPrefix = prefixSegments.joinToString("_")
+            return listOfNotNull(
+                identifierPrefix.takeIf { it.isNotEmpty() },
+                identifierSuffix.takeIf { it.isNotEmpty() }
+            ).joinToString("_")
         }
 
-        if (identifierSuffix.isEmpty()) {
-            return null
+        val identifierPrefix = prefixSegments.joinToString("_")
+        if (identifierPrefix.isNotEmpty()) {
+            return identifierPrefix
         }
 
-        return (prefixSegments + identifierSuffix).joinToString("_")
+        val fallbackSuffix = address.replace(":", "").takeLast(6)
+        return fallbackSuffix.takeIf { it.isNotEmpty() }
     }
 
     private fun displayNameFromDeviceName(rawName: String): String? {

--- a/core/src/main/java/io/texne/g1/basis/core/G1.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/G1.kt
@@ -282,20 +282,25 @@ class G1 {
                 return null
             }
 
-            val prefixSegments = segments.take(sideIndex)
-            val suffixSegments = segments.drop(sideIndex + 1)
+            val prefixSegments = segments.take(sideIndex).filter { it.isNotEmpty() }
+            val suffixSegments = segments.drop(sideIndex + 1).filter { it.isNotEmpty() }
 
-            val identifierSuffix = if (suffixSegments.isNotEmpty()) {
-                suffixSegments.joinToString("_")
-            } else {
-                address.replace(":", "").takeLast(6)
+            if (suffixSegments.isNotEmpty()) {
+                val identifierSuffix = suffixSegments.joinToString("_")
+                val identifierPrefix = prefixSegments.joinToString("_")
+                return listOfNotNull(
+                    identifierPrefix.takeIf { it.isNotEmpty() },
+                    identifierSuffix.takeIf { it.isNotEmpty() }
+                ).joinToString("_")
             }
 
-            if (identifierSuffix.isEmpty()) {
-                return null
+            val identifierPrefix = prefixSegments.joinToString("_")
+            if (identifierPrefix.isNotEmpty()) {
+                return identifierPrefix
             }
 
-            return (prefixSegments + identifierSuffix).joinToString("_")
+            val fallbackSuffix = address.replace(":", "").takeLast(6)
+            return fallbackSuffix.takeIf { it.isNotEmpty() }
         }
 
         private fun String.hasSideToken(side: String): Boolean =

--- a/core/src/test/java/io/texne/g1/basis/core/G1FindTest.kt
+++ b/core/src/test/java/io/texne/g1/basis/core/G1FindTest.kt
@@ -51,7 +51,7 @@ class G1FindTest {
     }
 
     @Test
-    fun `pairs without suffix fallback to address for identifiers`() {
+    fun `pairs without suffix share base identifier`() {
         val foundAddresses = mutableListOf<String>()
         val foundPairs = mutableMapOf<String, G1.Companion.FoundPair>()
 
@@ -68,7 +68,7 @@ class G1FindTest {
         assertTrue("No partial pairs should remain", foundPairs.isEmpty())
 
         val identifiers = completed.map { it.identifier }.toSet()
-        assertEquals("Pairs should have unique identifiers", 2, identifiers.size)
+        assertEquals("Pairs without suffix should share identifier", setOf("Even G1_7"), identifiers)
         assertEquals(
             listOf(
                 "AA:BB:CC:DD:10:01",


### PR DESCRIPTION
## Summary
- adjust the pairing identifier to reuse the base device token when no suffix is present so opposite sides are grouped together
- mirror the updated identifier logic in the client helper to keep service and client behavior consistent
- refresh the find tests to cover the shared identifier scenario for suffix-less device names

## Testing
- ./gradlew core:test *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9a6f0edc83329b875549131ba681