### PR TITLE
Ensure notification enabling request is enqueued

### DIFF
--- a/core/src/main/java/io/texne/g1/basis/core/G1BLEManager.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/G1BLEManager.kt
@@ -105,6 +105,13 @@ internal class G1BLEManager(private val deviceName: String, context: Context, pr
             }
         }
         enableNotifications(notificationCharacteristic)
+            .fail { _, status ->
+                Log.e(
+                    "G1BLEManager",
+                    "Failed to enable notifications for $deviceName (status: $status)"
+                )
+            }
+            .enqueue()
     }
 
     //


### PR DESCRIPTION
## Summary
- ensure the notification enabling request is enqueued so the descriptor write executes
- log the GATT status when enabling notifications fails for easier debugging

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfa604b0f88332ac2c59569c431c8b