### PR TITLE
Improve BLE error logging

### DIFF
--- a/core/src/main/java/io/texne/g1/basis/core/G1BLEManager.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/G1BLEManager.kt
@@ -126,7 +126,13 @@ internal class G1BLEManager(private val deviceName: String, context: Context, pr
                 ).await()
                 true
             } catch (e: Exception) {
-                // the request failed
+                val attemptNumber = 3 - attemptsRemaining
+                val status = writableConnectionState.value
+                Log.e(
+                    "G1BLEManager",
+                    "Failed to send packet on attempt $attemptNumber (status=$status): ${e.message}",
+                    e
+                )
                 false
             }
         }

--- a/core/src/main/java/io/texne/g1/basis/core/G1Device.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/G1Device.kt
@@ -130,7 +130,10 @@ internal class G1Device(
             )
             successfullySent = manager.send(nextRequest.outgoing)
             if(!successfullySent) {
-                // TODO: log send error
+                Log.e(
+                    "G1Device",
+                    "Failed to send request ${nextRequest.outgoing.type}; invoking failure callback"
+                )
                 nextRequest.callback(null)
                 nextRequest = queuedRequests.removeFirstOrNull()
             }
@@ -189,12 +192,19 @@ internal class G1Device(
 
     private fun sendBatteryCheck() {
         if(!manager.send(BatteryLevelRequestPacket())) {
-            // TODO: log error
+            Log.e(
+                "G1Device",
+                "Heartbeat battery check failed to send"
+            )
         }
 
         // if current request has expired, return failure and advance queue
         val request = currentRequest
         if(request != null && request.expires < Date().time) {
+            Log.w(
+                "G1Device",
+                "Request ${request.outgoing.type} expired before response; advancing queue"
+            )
             request.callback(null)
             advanceQueue()
         }


### PR DESCRIPTION
## Summary
- log BLE send exceptions with connection status in `G1BLEManager`
- add logging for queue send failures, expired requests, and heartbeat send errors in `G1Device`

## Testing
- ./gradlew :core:compileDebugKotlin *(fails: Android SDK not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfa691ed888332b19d3937c2bf37cc