### PR TITLE
Prefer scan record name for candidate discovery

### DIFF
--- a/core/src/main/java/io/texne/g1/basis/core/G1.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/G1.kt
@@ -314,7 +314,7 @@ class G1 {
 
         private fun candidateFromScanResult(result: ScanResult): DeviceCandidate? {
             val device = result.device
-            val name = device.name ?: return null
+            val name = result.scanRecord?.deviceName ?: device.name ?: return null
             if (!name.startsWith(DEVICE_NAME_PREFIX)) {
                 return null
             }


### PR DESCRIPTION
## Summary
- prefer Bluetooth LE scan record device name when parsing candidate information
- fall back to the device name if the scan record is unavailable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfb615e67c833299228f978333a8b7