### PR TITLE
Prefer scan record name from BLE scan results

### DIFF
--- a/core/src/main/java/io/texne/g1/basis/core/G1.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/G1.kt
@@ -314,7 +314,8 @@ class G1 {
 
         private fun candidateFromScanResult(result: ScanResult): DeviceCandidate? {
             val device = result.device
-            val name = result.scanRecord?.deviceName ?: device.name ?: return null
+            val scanRecordName = result.scanRecord?.deviceName
+            val name = scanRecordName ?: result.device.name ?: return null
             if (!name.startsWith(DEVICE_NAME_PREFIX)) {
                 return null
             }


### PR DESCRIPTION
## Summary
- prefer the device name provided by the scan record when building candidates
- fall back to the Bluetooth device name only if the scan record lacks a name

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfbbf9f8c08332bf3342721f3db993