### PR TITLE
Add debug view model and screen

### DIFF
--- a/hub/src/main/java/io/texne/g1/hub/ui/debug/DebugInfoFormatter.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/debug/DebugInfoFormatter.kt
@@ -1,0 +1,204 @@
+package io.texne.g1.hub.ui.debug
+
+import io.texne.g1.basis.client.G1ServiceCommon
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import javax.inject.Inject
+
+class DebugInfoFormatter @Inject constructor() {
+    fun format(snapshot: DebugSnapshot): String {
+        val builder = StringBuilder()
+        builder.appendLine("G1 Hub Debug Snapshot")
+        builder.appendLine("Captured: ${formatTimestamp(snapshot.timestampMillis)}")
+        builder.appendLine()
+
+        val os = snapshot.osInfo
+        builder.appendLine("[Environment]")
+        builder.appendLine("App version: ${os.appVersionName}")
+        builder.appendLine("Device: ${os.manufacturer} ${os.model}")
+        builder.appendLine("Android: ${os.release} (SDK ${os.sdkInt})")
+        builder.appendLine()
+
+        val bluetooth = snapshot.bluetoothInfo
+        builder.appendLine("[Bluetooth]")
+        val bluetoothStatus = when (bluetooth.enabled) {
+            true -> "Enabled"
+            false -> "Disabled"
+            null -> "Unavailable"
+        }
+        builder.appendLine("Adapter: $bluetoothStatus")
+        if (bluetooth.error != null) {
+            builder.appendLine("Error: ${bluetooth.error}")
+        }
+        if (bluetooth.bondedDevices.isEmpty()) {
+            builder.appendLine("Bonded devices: none")
+        } else {
+            builder.appendLine("Bonded devices:")
+            bluetooth.bondedDevices.forEach { device ->
+                builder.appendLine("  • ${device.name} (${device.address})")
+            }
+        }
+        builder.appendLine()
+
+        builder.appendLine("[Permissions]")
+        snapshot.permissionStatuses.forEach { permission ->
+            val statusLabel = if (permission.granted) "granted" else "denied"
+            builder.appendLine("${permission.permission}: $statusLabel")
+        }
+        builder.appendLine()
+
+        builder.appendLine("[Service]")
+        val service = snapshot.service
+        if (service == null) {
+            builder.appendLine("No service snapshot available.")
+        } else {
+            builder.appendLine("Status: ${service.status}")
+            if (service.glasses.isEmpty()) {
+                builder.appendLine("Glasses: none detected")
+            } else {
+                builder.appendLine("Glasses:")
+                service.glasses.forEach { glasses ->
+                    builder.appendLine("- ${glasses.name} (${glasses.id})")
+                    builder.appendLine("  status=${glasses.status} battery=${formatBattery(glasses.batteryPercentage)}")
+                    builder.appendLine(
+                        "  left=${glasses.leftStatus} (${formatBattery(glasses.leftBattery)}) " +
+                            "right=${glasses.rightStatus} (${formatBattery(glasses.rightBattery)})"
+                    )
+                    builder.appendLine(
+                        "  signal=${glasses.signalStrength?.toString() ?: "—"} " +
+                            "rssi=${glasses.rssi?.let { "$it dBm" } ?: "—"}"
+                    )
+                }
+            }
+        }
+        builder.appendLine()
+
+        builder.appendLine("[Scan history]")
+        if (snapshot.scanHistory.isEmpty()) {
+            builder.appendLine("No scan history available.")
+        } else {
+            snapshot.scanHistory.forEach { entry ->
+                val connected = if (entry.connectedNames.isEmpty()) {
+                    "connected=—"
+                } else {
+                    "connected=${entry.connectedNames.joinToString()}"
+                }
+                builder.appendLine(
+                    "- ${formatTimestamp(entry.timestampMillis)} • status=${entry.status} • " +
+                        "discovered=${entry.discoveredCount} • $connected"
+                )
+            }
+        }
+        builder.appendLine()
+
+        builder.appendLine("[Gesture history]")
+        if (snapshot.gestureHistory.isEmpty()) {
+            builder.appendLine("No trigger history available.")
+        } else {
+            snapshot.gestureHistory.forEach { entry ->
+                builder.appendLine(
+                    "- ${formatTimestamp(entry.timestampMillis)} • seq=${entry.sequence} • " +
+                        "${entry.type}/${entry.side}"
+                )
+            }
+        }
+        builder.appendLine()
+
+        builder.appendLine("[Error logs]")
+        if (snapshot.errorLogs.isEmpty()) {
+            builder.appendLine("No stored error logs.")
+        } else {
+            snapshot.errorLogs.forEach { (name, logs) ->
+                builder.appendLine("- $name")
+                if (logs.isEmpty()) {
+                    builder.appendLine("  (no entries)")
+                } else {
+                    logs.forEach { logEntry ->
+                        builder.appendLine("  • $logEntry")
+                    }
+                }
+            }
+        }
+
+        return builder.toString().trimEnd()
+    }
+
+    fun formatTimestamp(millis: Long): String = TIMESTAMP_FORMATTER.format(Date(millis))
+
+    fun buildFileName(timestampMillis: Long): String = "g1-debug-${FILE_NAME_FORMATTER.format(Date(timestampMillis))}.txt"
+
+    private fun formatBattery(value: Int): String = if (value >= 0) "$value%" else "—"
+
+    private companion object {
+        private val TIMESTAMP_FORMATTER = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS z", Locale.US)
+        private val FILE_NAME_FORMATTER = SimpleDateFormat("yyyyMMdd-HHmmss", Locale.US)
+    }
+}
+
+data class DebugSnapshot(
+    val timestampMillis: Long,
+    val osInfo: OsInfo,
+    val bluetoothInfo: BluetoothInfo,
+    val permissionStatuses: List<PermissionStatus>,
+    val service: ServiceSnapshot?,
+    val scanHistory: List<ScanHistoryEntry>,
+    val gestureHistory: List<GestureHistoryEntry>,
+    val errorLogs: Map<String, List<String>>
+) {
+    data class OsInfo(
+        val release: String,
+        val sdkInt: Int,
+        val manufacturer: String,
+        val model: String,
+        val appVersionName: String
+    )
+
+    data class BluetoothInfo(
+        val enabled: Boolean?,
+        val bondedDevices: List<BondedDevice>,
+        val error: String?
+    ) {
+        data class BondedDevice(
+            val name: String,
+            val address: String
+        )
+    }
+
+    data class PermissionStatus(
+        val permission: String,
+        val granted: Boolean
+    )
+
+    data class ServiceSnapshot(
+        val status: G1ServiceCommon.ServiceStatus,
+        val glasses: List<Glasses>
+    ) {
+        data class Glasses(
+            val id: String,
+            val name: String,
+            val status: G1ServiceCommon.GlassesStatus,
+            val batteryPercentage: Int,
+            val leftStatus: G1ServiceCommon.GlassesStatus,
+            val leftBattery: Int,
+            val rightStatus: G1ServiceCommon.GlassesStatus,
+            val rightBattery: Int,
+            val signalStrength: Int?,
+            val rssi: Int?
+        )
+    }
+
+    data class ScanHistoryEntry(
+        val timestampMillis: Long,
+        val status: G1ServiceCommon.ServiceStatus,
+        val discoveredCount: Int,
+        val connectedNames: List<String>
+    )
+
+    data class GestureHistoryEntry(
+        val sequence: Int,
+        val timestampMillis: Long,
+        val type: G1ServiceCommon.GestureType,
+        val side: G1ServiceCommon.GestureSide
+    )
+}

--- a/hub/src/main/java/io/texne/g1/hub/ui/debug/DebugLogModule.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/debug/DebugLogModule.kt
@@ -1,0 +1,13 @@
+package io.texne.g1.hub.ui.debug
+
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.Multibinds
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class DebugLogModule {
+    @Multibinds
+    abstract fun bindDebugLogProviders(): Set<DebugLogProvider>
+}

--- a/hub/src/main/java/io/texne/g1/hub/ui/debug/DebugLogProvider.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/debug/DebugLogProvider.kt
@@ -1,0 +1,12 @@
+package io.texne.g1.hub.ui.debug
+
+/**
+ * Supplies stored log entries that should be surfaced in the debug panel.
+ */
+interface DebugLogProvider {
+    /** Human readable name for the log source. */
+    val name: String
+
+    /** Returns stored log entries ordered from oldest to newest. */
+    suspend fun getLogs(): List<String>
+}

--- a/hub/src/main/java/io/texne/g1/hub/ui/debug/DebugPanelScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/debug/DebugPanelScreen.kt
@@ -1,0 +1,122 @@
+package io.texne.g1.hub.ui.debug
+
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material3.Button
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+@Composable
+fun DebugPanelScreen(
+    modifier: Modifier = Modifier,
+    viewModel: DebugViewModel = hiltViewModel()
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val scrollState = rememberScrollState()
+    val context = LocalContext.current
+
+    LaunchedEffect(state.message) {
+        state.message?.let { message ->
+            val duration = if (message.isError) Toast.LENGTH_LONG else Toast.LENGTH_SHORT
+            Toast.makeText(context, message.text, duration).show()
+            viewModel.consumeMessage()
+        }
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(
+            text = "Debug Panel",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold
+        )
+        state.lastUpdatedLabel?.let { label ->
+            Text(
+                text = "Last updated: $label",
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
+        if (state.isRefreshing) {
+            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Button(
+                onClick = viewModel::refresh,
+                enabled = !state.isRefreshing
+            ) {
+                Text("Refresh")
+            }
+            OutlinedButton(onClick = viewModel::toggleAutoRefresh) {
+                val label = if (state.autoRefreshEnabled) {
+                    "Disable auto refresh"
+                } else {
+                    "Enable auto refresh"
+                }
+                Text(label)
+            }
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            OutlinedButton(onClick = viewModel::copyToClipboard) {
+                Text("Copy")
+            }
+            OutlinedButton(onClick = viewModel::exportToFile) {
+                Text("Export")
+            }
+            OutlinedButton(onClick = viewModel::share) {
+                Text("Share")
+            }
+        }
+        Surface(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth(),
+            tonalElevation = 2.dp
+        ) {
+            SelectionContainer {
+                Box(
+                    modifier = Modifier
+                        .verticalScroll(scrollState)
+                        .padding(16.dp)
+                        .fillMaxWidth()
+                ) {
+                    val text = state.formattedText.ifBlank { "Debug information will appear after refresh." }
+                    Text(text = text, style = MaterialTheme.typography.bodySmall)
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+    }
+}

--- a/hub/src/main/java/io/texne/g1/hub/ui/debug/DebugViewModel.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/debug/DebugViewModel.kt
@@ -1,0 +1,415 @@
+package io.texne.g1.hub.ui.debug
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.app.Application
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Environment
+import android.util.Log
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.texne.g1.basis.client.G1ServiceCommon
+import io.texne.g1.hub.BuildConfig
+import io.texne.g1.hub.model.Repository
+import javax.inject.Inject
+import kotlin.collections.ArrayDeque
+import kotlin.jvm.JvmSuppressWildcards
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import java.io.File
+import java.io.IOException
+import java.util.Locale
+
+@HiltViewModel
+class DebugViewModel @Inject constructor(
+    private val application: Application,
+    private val repository: Repository,
+    private val logProviders: Set<@JvmSuppressWildcards DebugLogProvider>,
+    private val formatter: DebugInfoFormatter
+) : ViewModel() {
+
+    data class DebugUiState(
+        val formattedText: String = "",
+        val exportFileName: String = "",
+        val lastUpdatedLabel: String? = null,
+        val autoRefreshEnabled: Boolean = false,
+        val isRefreshing: Boolean = false,
+        val message: DebugMessage? = null
+    )
+
+    data class DebugMessage(
+        val text: String,
+        val isError: Boolean = false
+    )
+
+    private val _state = MutableStateFlow(DebugUiState())
+    val state: StateFlow<DebugUiState> = _state.asStateFlow()
+
+    private var autoRefreshJob: kotlinx.coroutines.Job? = null
+    private var latestServiceSnapshot: Repository.ServiceSnapshot? = null
+    private val scanHistory = ArrayDeque<DebugSnapshot.ScanHistoryEntry>()
+    private val gestureHistory = ArrayDeque<DebugSnapshot.GestureHistoryEntry>()
+    private var lastRecordedStatus: G1ServiceCommon.ServiceStatus? = null
+
+    init {
+        observeRepository()
+        refresh()
+    }
+
+    fun refresh() {
+        viewModelScope.launch { performRefresh() }
+    }
+
+    fun toggleAutoRefresh() {
+        val enable = autoRefreshJob == null
+        if (enable) {
+            autoRefreshJob = viewModelScope.launch {
+                emitMessage(DebugMessage("Auto-refresh enabled"))
+                while (isActive) {
+                    performRefresh()
+                    delay(AUTO_REFRESH_INTERVAL_MILLIS)
+                }
+            }
+        } else {
+            autoRefreshJob?.cancel()
+            autoRefreshJob = null
+            emitMessage(DebugMessage("Auto-refresh disabled"))
+        }
+        _state.update { it.copy(autoRefreshEnabled = enable) }
+    }
+
+    fun copyToClipboard() {
+        viewModelScope.launch {
+            val text = state.value.formattedText
+            if (text.isBlank()) {
+                emitMessage(DebugMessage("No debug information to copy", isError = true))
+                return@launch
+            }
+            try {
+                val clipboard = ContextCompat.getSystemService(application, ClipboardManager::class.java)
+                if (clipboard == null) {
+                    emitMessage(DebugMessage("Clipboard service unavailable", isError = true))
+                    return@launch
+                }
+                clipboard.setPrimaryClip(ClipData.newPlainText("G1 Hub debug", text))
+                emitMessage(DebugMessage("Debug information copied to clipboard"))
+            } catch (error: Exception) {
+                Log.e(TAG, "Failed to copy debug info", error)
+                emitMessage(
+                    DebugMessage(
+                        text = "Failed to copy debug info: ${error.message ?: error::class.java.simpleName}",
+                        isError = true
+                    )
+                )
+            }
+        }
+    }
+
+    fun exportToFile() {
+        viewModelScope.launch(Dispatchers.IO) {
+            val currentState = state.value
+            val text = currentState.formattedText
+            if (text.isBlank()) {
+                emitMessage(DebugMessage("No debug information to export", isError = true))
+                return@launch
+            }
+            try {
+                val fileName = currentState.exportFileName.ifBlank {
+                    formatter.buildFileName(System.currentTimeMillis())
+                }
+                val directory = application.getExternalFilesDir(Environment.DIRECTORY_DOCUMENTS)
+                    ?: application.filesDir
+                if (!directory.exists()) {
+                    directory.mkdirs()
+                }
+                val file = File(directory, fileName)
+                file.writeText(text)
+                emitMessage(DebugMessage("Exported to ${file.absolutePath}"))
+            } catch (error: IOException) {
+                Log.e(TAG, "Failed to export debug info", error)
+                emitMessage(
+                    DebugMessage(
+                        text = "Failed to export debug info: ${error.message ?: error::class.java.simpleName}",
+                        isError = true
+                    )
+                )
+            }
+        }
+    }
+
+    fun share() {
+        viewModelScope.launch {
+            val text = state.value.formattedText
+            if (text.isBlank()) {
+                emitMessage(DebugMessage("No debug information to share", isError = true))
+                return@launch
+            }
+            try {
+                val shareIntent = Intent(Intent.ACTION_SEND).apply {
+                    type = "text/plain"
+                    putExtra(Intent.EXTRA_SUBJECT, "G1 Hub debug report")
+                    putExtra(Intent.EXTRA_TEXT, text)
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                val chooser = Intent.createChooser(shareIntent, "Share debug info").apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                application.startActivity(chooser)
+                emitMessage(DebugMessage("Share sheet opened"))
+            } catch (error: Exception) {
+                Log.e(TAG, "Failed to share debug info", error)
+                emitMessage(
+                    DebugMessage(
+                        text = "Failed to share debug info: ${error.message ?: error::class.java.simpleName}",
+                        isError = true
+                    )
+                )
+            }
+        }
+    }
+
+    fun consumeMessage() {
+        _state.update { it.copy(message = null) }
+    }
+
+    private fun observeRepository() {
+        viewModelScope.launch {
+            repository.getServiceStateFlow().collect { snapshot ->
+                latestServiceSnapshot = snapshot
+                val status = snapshot?.status
+                if (status != null && status != lastRecordedStatus) {
+                    lastRecordedStatus = status
+                    recordScanHistory(status, snapshot)
+                }
+            }
+        }
+        viewModelScope.launch {
+            repository.gestureEvents().collect { event ->
+                recordGesture(event)
+            }
+        }
+    }
+
+    private fun emitMessage(message: DebugMessage) {
+        _state.update { it.copy(message = message) }
+    }
+
+    private suspend fun performRefresh() {
+        _state.update { it.copy(isRefreshing = true) }
+        try {
+            val snapshot = withContext(Dispatchers.IO) { buildDebugSnapshot() }
+            val formatted = formatter.format(snapshot)
+            val fileName = formatter.buildFileName(snapshot.timestampMillis)
+            val lastUpdated = formatter.formatTimestamp(snapshot.timestampMillis)
+            _state.update {
+                it.copy(
+                    formattedText = formatted,
+                    exportFileName = fileName,
+                    lastUpdatedLabel = lastUpdated,
+                    isRefreshing = false
+                )
+            }
+        } catch (error: Exception) {
+            Log.e(TAG, "Failed to refresh debug info", error)
+            emitMessage(
+                DebugMessage(
+                    text = "Failed to refresh debug info: ${error.message ?: error::class.java.simpleName}",
+                    isError = true
+                )
+            )
+            _state.update { it.copy(isRefreshing = false) }
+        }
+    }
+
+    private suspend fun buildDebugSnapshot(): DebugSnapshot {
+        val serviceSnapshot = latestServiceSnapshot
+        val timestamp = System.currentTimeMillis()
+        val osInfo = DebugSnapshot.OsInfo(
+            release = Build.VERSION.RELEASE ?: "Unknown",
+            sdkInt = Build.VERSION.SDK_INT,
+            manufacturer = Build.MANUFACTURER,
+            model = Build.MODEL,
+            appVersionName = BuildConfig.VERSION_NAME
+        )
+        val bluetoothInfo = loadBluetoothInfo()
+        val permissions = gatherPermissionStatuses()
+        val scanHistorySnapshot = scanHistory.toList()
+        val gestureSnapshot = gestureHistory.toList()
+        val errorLogs = loadErrorLogs()
+        return DebugSnapshot(
+            timestampMillis = timestamp,
+            osInfo = osInfo,
+            bluetoothInfo = bluetoothInfo,
+            permissionStatuses = permissions,
+            service = mapServiceSnapshot(serviceSnapshot),
+            scanHistory = scanHistorySnapshot,
+            gestureHistory = gestureSnapshot,
+            errorLogs = errorLogs
+        )
+    }
+
+    private fun recordScanHistory(
+        status: G1ServiceCommon.ServiceStatus,
+        snapshot: Repository.ServiceSnapshot?
+    ) {
+        val connected = snapshot?.glasses?.filter { it.status == G1ServiceCommon.GlassesStatus.CONNECTED }?.map { it.name }
+            ?: emptyList()
+        val entry = DebugSnapshot.ScanHistoryEntry(
+            timestampMillis = System.currentTimeMillis(),
+            status = status,
+            discoveredCount = snapshot?.glasses?.size ?: 0,
+            connectedNames = connected
+        )
+        scanHistory.addFirst(entry)
+        while (scanHistory.size > HISTORY_LIMIT) {
+            scanHistory.removeLast()
+        }
+    }
+
+    private fun recordGesture(event: G1ServiceCommon.GestureEvent) {
+        val entry = DebugSnapshot.GestureHistoryEntry(
+            sequence = event.sequence,
+            timestampMillis = event.timestampMillis,
+            type = event.type,
+            side = event.side
+        )
+        gestureHistory.addFirst(entry)
+        while (gestureHistory.size > HISTORY_LIMIT) {
+            gestureHistory.removeLast()
+        }
+    }
+
+    private suspend fun loadErrorLogs(): Map<String, List<String>> {
+        if (logProviders.isEmpty()) {
+            return emptyMap()
+        }
+        val sortedProviders = logProviders.sortedBy { it.name.lowercase(Locale.ROOT) }
+        val result = linkedMapOf<String, List<String>>()
+        for (provider in sortedProviders) {
+            try {
+                result[provider.name] = provider.getLogs()
+            } catch (error: Exception) {
+                Log.e(TAG, "Failed to read logs from ${provider.name}", error)
+                result[provider.name] = listOf(
+                    "Failed to load logs: ${error.message ?: error::class.java.simpleName}"
+                )
+            }
+        }
+        return result
+    }
+
+    private fun gatherPermissionStatuses(): List<DebugSnapshot.PermissionStatus> {
+        val permissions = mutableListOf<DebugSnapshot.PermissionStatus>()
+        permissions += DebugSnapshot.PermissionStatus(
+            permission = Manifest.permission.ACCESS_FINE_LOCATION,
+            granted = ContextCompat.checkSelfPermission(
+                application,
+                Manifest.permission.ACCESS_FINE_LOCATION
+            ) == PackageManager.PERMISSION_GRANTED
+        )
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            listOf(
+                Manifest.permission.BLUETOOTH_SCAN,
+                Manifest.permission.BLUETOOTH_CONNECT
+            ).forEach { permission ->
+                permissions += DebugSnapshot.PermissionStatus(
+                    permission = permission,
+                    granted = ContextCompat.checkSelfPermission(application, permission) == PackageManager.PERMISSION_GRANTED
+                )
+            }
+        }
+        return permissions
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun loadBluetoothInfo(): DebugSnapshot.BluetoothInfo {
+        val manager = ContextCompat.getSystemService(application, BluetoothManager::class.java)
+        val adapter = manager?.adapter ?: BluetoothAdapter.getDefaultAdapter()
+        if (adapter == null) {
+            return DebugSnapshot.BluetoothInfo(
+                enabled = null,
+                bondedDevices = emptyList(),
+                error = "Bluetooth adapter unavailable"
+            )
+        }
+        val enabled = adapter.isEnabled
+        val bonded = mutableListOf<DebugSnapshot.BluetoothInfo.BondedDevice>()
+        var errorMessage: String? = null
+        val canReadBonded = Build.VERSION.SDK_INT < Build.VERSION_CODES.S ||
+            ContextCompat.checkSelfPermission(application, Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED
+        if (canReadBonded) {
+            try {
+                val devices = adapter.bondedDevices ?: emptySet()
+                devices.forEach { device ->
+                    bonded += DebugSnapshot.BluetoothInfo.BondedDevice(
+                        name = device.name ?: "(unknown)",
+                        address = device.address
+                    )
+                }
+            } catch (error: SecurityException) {
+                Log.w(TAG, "Unable to access bonded devices", error)
+                errorMessage = error.message ?: error::class.java.simpleName
+            } catch (error: Exception) {
+                Log.w(TAG, "Unexpected error while reading bonded devices", error)
+                errorMessage = error.message ?: error::class.java.simpleName
+            }
+        } else {
+            errorMessage = "Missing BLUETOOTH_CONNECT permission"
+        }
+        bonded.sortBy { it.name.lowercase(Locale.ROOT) }
+        return DebugSnapshot.BluetoothInfo(
+            enabled = enabled,
+            bondedDevices = bonded,
+            error = errorMessage
+        )
+    }
+
+    private fun mapServiceSnapshot(snapshot: Repository.ServiceSnapshot?): DebugSnapshot.ServiceSnapshot? {
+        return snapshot?.let {
+            DebugSnapshot.ServiceSnapshot(
+                status = it.status,
+                glasses = it.glasses.map { glasses ->
+                    DebugSnapshot.ServiceSnapshot.Glasses(
+                        id = glasses.id,
+                        name = glasses.name,
+                        status = glasses.status,
+                        batteryPercentage = glasses.batteryPercentage,
+                        leftStatus = glasses.left.status,
+                        leftBattery = glasses.left.batteryPercentage,
+                        rightStatus = glasses.right.status,
+                        rightBattery = glasses.right.batteryPercentage,
+                        signalStrength = glasses.signalStrength,
+                        rssi = glasses.rssi
+                    )
+                }
+            )
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        autoRefreshJob?.cancel()
+        autoRefreshJob = null
+    }
+
+    companion object {
+        private const val TAG = "DebugViewModel"
+        private const val AUTO_REFRESH_INTERVAL_MILLIS = 5_000L
+        private const val HISTORY_LIMIT = 20
+    }
+}


### PR DESCRIPTION
## Summary
- add a debug log provider interface and multibinding module
- implement the DebugViewModel to capture app, bluetooth, repository, and log snapshots with export/copy/share helpers
- connect the view model to a DebugPanelScreen that surfaces the formatted snapshot and actions

## Testing
- ./gradlew :hub:assembleDebug *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfbf2161288332942231bd8d40e0fc