### PR TITLE
Add detailed connection diagnostics and scan history

### DIFF
--- a/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/G1Glasses.aidl
+++ b/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/G1Glasses.aidl
@@ -8,6 +8,7 @@ parcelable G1Glasses {
     const int CONNECTED = 3;
     const int DISCONNECTING = 4;
     const int ERROR = 666;
+    const int MTU_UNKNOWN = 0;
 
     String id;
     String name;
@@ -19,4 +20,17 @@ parcelable G1Glasses {
     int rightBatteryPercentage;
     int signalStrength;
     int rssi;
+    String leftMacAddress;
+    String rightMacAddress;
+    int leftNegotiatedMtu;
+    int rightNegotiatedMtu;
+    long leftLastConnectionAttemptMillis;
+    long rightLastConnectionAttemptMillis;
+    long leftLastConnectionSuccessMillis;
+    long rightLastConnectionSuccessMillis;
+    long leftLastDisconnectMillis;
+    long rightLastDisconnectMillis;
+    long lastConnectionAttemptMillis;
+    long lastConnectionSuccessMillis;
+    long lastDisconnectMillis;
 }

--- a/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/G1ScanResult.aidl
+++ b/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/G1ScanResult.aidl
@@ -1,0 +1,10 @@
+// G1ScanResult.aidl
+package io.texne.g1.basis.service.protocol;
+
+parcelable G1ScanResult {
+    String id;
+    String name;
+    int signalStrength;
+    int rssi;
+    long timestampMillis;
+}

--- a/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/G1ServiceState.aidl
+++ b/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/G1ServiceState.aidl
@@ -3,6 +3,7 @@ package io.texne.g1.basis.service.protocol;
 
 import io.texne.g1.basis.service.protocol.G1Glasses;
 import io.texne.g1.basis.service.protocol.G1GestureEvent;
+import io.texne.g1.basis.service.protocol.G1ScanResult;
 
 parcelable G1ServiceState {
     const int READY = 1;
@@ -13,4 +14,7 @@ parcelable G1ServiceState {
     int status;
     G1Glasses[] glasses;
     G1GestureEvent gestureEvent;
+    long[] scanTriggerTimestamps;
+    G1ScanResult[] recentScanResults;
+    String lastConnectedId;
 }

--- a/client/src/main/java/io/texne/g1/basis/client/G1ServiceCommon.kt
+++ b/client/src/main/java/io/texne/g1/basis/client/G1ServiceCommon.kt
@@ -14,6 +14,8 @@ import java.io.Closeable
 
 const val MAX_LINES_PER_PAGE = 5
 const val MAX_CHARACTERS_PER_LINE = 40
+const val MTU_UNKNOWN = 0
+const val TIMESTAMP_UNKNOWN = 0L
 
 abstract class G1ServiceCommon<ServiceInterface> constructor(
     private val context: Context
@@ -31,14 +33,38 @@ abstract class G1ServiceCommon<ServiceInterface> constructor(
         val leftBatteryPercentage: Int,
         val rightBatteryPercentage: Int,
         val signalStrength: Int = SIGNAL_STRENGTH_UNKNOWN,
-        val rssi: Int = RSSI_UNKNOWN
+        val rssi: Int = RSSI_UNKNOWN,
+        val leftMacAddress: String = "",
+        val rightMacAddress: String = "",
+        val leftNegotiatedMtu: Int = MTU_UNKNOWN,
+        val rightNegotiatedMtu: Int = MTU_UNKNOWN,
+        val leftLastConnectionAttemptMillis: Long = TIMESTAMP_UNKNOWN,
+        val rightLastConnectionAttemptMillis: Long = TIMESTAMP_UNKNOWN,
+        val leftLastConnectionSuccessMillis: Long = TIMESTAMP_UNKNOWN,
+        val rightLastConnectionSuccessMillis: Long = TIMESTAMP_UNKNOWN,
+        val leftLastDisconnectMillis: Long = TIMESTAMP_UNKNOWN,
+        val rightLastDisconnectMillis: Long = TIMESTAMP_UNKNOWN,
+        val lastConnectionAttemptMillis: Long = TIMESTAMP_UNKNOWN,
+        val lastConnectionSuccessMillis: Long = TIMESTAMP_UNKNOWN,
+        val lastDisconnectMillis: Long = TIMESTAMP_UNKNOWN
     )
 
     enum class ServiceStatus { READY, LOOKING, LOOKED, ERROR }
 
+    data class ScanResult(
+        val id: String,
+        val name: String,
+        val signalStrength: Int = SIGNAL_STRENGTH_UNKNOWN,
+        val rssi: Int = RSSI_UNKNOWN,
+        val timestampMillis: Long = TIMESTAMP_UNKNOWN
+    )
+
     data class State(
         val status: ServiceStatus,
-        val glasses: List<Glasses>
+        val glasses: List<Glasses>,
+        val scanTriggerTimestamps: List<Long> = emptyList(),
+        val recentScanResults: List<ScanResult> = emptyList(),
+        val lastConnectedId: String? = null
     )
 
     protected val writableState =

--- a/client/src/main/java/io/texne/g1/basis/client/G1ServiceManager.kt
+++ b/client/src/main/java/io/texne/g1/basis/client/G1ServiceManager.kt
@@ -108,9 +108,33 @@ class G1ServiceManager private constructor(context: Context): G1ServiceCommon<IG
                                     leftBatteryPercentage = glass.leftBatteryPercentage,
                                     rightBatteryPercentage = glass.rightBatteryPercentage,
                                     signalStrength = glass.signalStrength,
-                                    rssi = glass.rssi
+                                    rssi = glass.rssi,
+                                    leftMacAddress = glass.leftMacAddress ?: "",
+                                    rightMacAddress = glass.rightMacAddress ?: "",
+                                    leftNegotiatedMtu = glass.leftNegotiatedMtu,
+                                    rightNegotiatedMtu = glass.rightNegotiatedMtu,
+                                    leftLastConnectionAttemptMillis = glass.leftLastConnectionAttemptMillis,
+                                    rightLastConnectionAttemptMillis = glass.rightLastConnectionAttemptMillis,
+                                    leftLastConnectionSuccessMillis = glass.leftLastConnectionSuccessMillis,
+                                    rightLastConnectionSuccessMillis = glass.rightLastConnectionSuccessMillis,
+                                    leftLastDisconnectMillis = glass.leftLastDisconnectMillis,
+                                    rightLastDisconnectMillis = glass.rightLastDisconnectMillis,
+                                    lastConnectionAttemptMillis = glass.lastConnectionAttemptMillis,
+                                    lastConnectionSuccessMillis = glass.lastConnectionSuccessMillis,
+                                    lastDisconnectMillis = glass.lastDisconnectMillis
                                 )
-                            }
+                            },
+                            scanTriggerTimestamps = newState.scanTriggerTimestamps?.toList() ?: emptyList(),
+                            recentScanResults = newState.recentScanResults?.map { result ->
+                                ScanResult(
+                                    id = result.id,
+                                    name = result.name,
+                                    signalStrength = result.signalStrength,
+                                    rssi = result.rssi,
+                                    timestampMillis = result.timestampMillis
+                                )
+                            } ?: emptyList(),
+                            lastConnectedId = newState.lastConnectedId
                         )
                     }
                 }

--- a/core/src/main/java/io/texne/g1/basis/core/G1.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/G1.kt
@@ -71,7 +71,20 @@ class G1 {
         val leftConnectionState: ConnectionState,
         val rightConnectionState: ConnectionState,
         val leftBatteryPercentage: Int?,
-        val rightBatteryPercentage: Int?
+        val rightBatteryPercentage: Int?,
+        val leftMacAddress: String,
+        val rightMacAddress: String,
+        val leftNegotiatedMtu: Int?,
+        val rightNegotiatedMtu: Int?,
+        val leftLastConnectionAttemptMillis: Long?,
+        val rightLastConnectionAttemptMillis: Long?,
+        val leftLastConnectionSuccessMillis: Long?,
+        val rightLastConnectionSuccessMillis: Long?,
+        val leftLastDisconnectMillis: Long?,
+        val rightLastDisconnectMillis: Long?,
+        val lastConnectionAttemptMillis: Long?,
+        val lastConnectionSuccessMillis: Long?,
+        val lastDisconnectMillis: Long?
     )
     val state: StateFlow<State>
     private var currentState: State? = null
@@ -104,26 +117,41 @@ class G1 {
                 rightBatteryPercentage
             )
 
+            val newState = State(
+                connectionState = connectionState,
+                batteryPercentage = batteryPercentage,
+                leftConnectionState = lConnectionState,
+                rightConnectionState = rConnectionState,
+                leftBatteryPercentage = leftBatteryPercentage,
+                rightBatteryPercentage = rightBatteryPercentage,
+                leftMacAddress = l.macAddress,
+                rightMacAddress = r.macAddress,
+                leftNegotiatedMtu = l.negotiatedMtu,
+                rightNegotiatedMtu = r.negotiatedMtu,
+                leftLastConnectionAttemptMillis = l.lastConnectionAttemptMillis,
+                rightLastConnectionAttemptMillis = r.lastConnectionAttemptMillis,
+                leftLastConnectionSuccessMillis = l.lastConnectionSuccessMillis,
+                rightLastConnectionSuccessMillis = r.lastConnectionSuccessMillis,
+                leftLastDisconnectMillis = l.lastDisconnectMillis,
+                rightLastDisconnectMillis = r.lastDisconnectMillis,
+                lastConnectionAttemptMillis = listOfNotNull(
+                    l.lastConnectionAttemptMillis,
+                    r.lastConnectionAttemptMillis
+                ).maxOrNull(),
+                lastConnectionSuccessMillis = listOfNotNull(
+                    l.lastConnectionSuccessMillis,
+                    r.lastConnectionSuccessMillis
+                ).maxOrNull(),
+                lastDisconnectMillis = listOfNotNull(
+                    l.lastDisconnectMillis,
+                    r.lastDisconnectMillis
+                ).maxOrNull()
+            )
+
             val current = currentState
-            if(
-                current != null &&
-                connectionState == current.connectionState &&
-                batteryPercentage == current.batteryPercentage &&
-                lConnectionState == current.leftConnectionState &&
-                rConnectionState == current.rightConnectionState &&
-                leftBatteryPercentage == current.leftBatteryPercentage &&
-                rightBatteryPercentage == current.rightBatteryPercentage
-            ) {
+            if (current != null && current == newState) {
                 current
             } else {
-                val newState = State(
-                    connectionState = connectionState,
-                    batteryPercentage = batteryPercentage,
-                    leftConnectionState = lConnectionState,
-                    rightConnectionState = rConnectionState,
-                    leftBatteryPercentage = leftBatteryPercentage,
-                    rightBatteryPercentage = rightBatteryPercentage
-                )
                 Log.d("G1", "G1_STATE - composing - ${l} and ${r} = ${newState}")
                 currentState = newState
                 newState

--- a/hub/src/main/java/io/texne/g1/hub/model/ScanHistoryStore.kt
+++ b/hub/src/main/java/io/texne/g1/hub/model/ScanHistoryStore.kt
@@ -1,0 +1,57 @@
+package io.texne.g1.hub.model
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import org.json.JSONArray
+import org.json.JSONException
+
+private val Context.scanHistoryDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "scan_history"
+)
+
+internal object ScanHistoryStore {
+    private const val MAX_ENTRIES = 100
+    private val ENTRIES_KEY = stringPreferencesKey("entries")
+
+    suspend fun store(context: Context, timestamps: List<Long>) {
+        val limited = timestamps.takeLast(MAX_ENTRIES)
+        runCatching {
+            context.scanHistoryDataStore.edit { preferences ->
+                preferences[ENTRIES_KEY] = encode(limited)
+            }
+        }
+    }
+
+    suspend fun read(context: Context): List<Long> {
+        return runCatching {
+            val raw = context.scanHistoryDataStore.data
+                .map { preferences -> preferences[ENTRIES_KEY] }
+                .first()
+            decode(raw)
+        }.getOrElse { emptyList() }
+    }
+
+    private fun encode(entries: List<Long>): String {
+        val json = JSONArray()
+        entries.forEach { json.put(it) }
+        return json.toString()
+    }
+
+    private fun decode(raw: String?): List<Long> {
+        if (raw.isNullOrEmpty()) {
+            return emptyList()
+        }
+        return try {
+            val array = JSONArray(raw)
+            List(array.length()) { index -> array.optLong(index) }
+        } catch (error: JSONException) {
+            emptyList()
+        }
+    }
+}

--- a/hub/src/main/java/io/texne/g1/hub/ui/debug/ConnectionLogProviderImpl.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/debug/ConnectionLogProviderImpl.kt
@@ -1,0 +1,14 @@
+package io.texne.g1.hub.ui.debug
+
+import io.texne.g1.hub.model.Repository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ConnectionLogProviderImpl @Inject constructor(
+    private val repository: Repository
+) : DebugLogProvider {
+    override val name: String = "Connection"
+
+    override suspend fun getLogs(): List<String> = repository.getConnectionLogs()
+}

--- a/hub/src/main/java/io/texne/g1/hub/ui/debug/DebugLogModule.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/debug/DebugLogModule.kt
@@ -1,8 +1,10 @@
 package io.texne.g1.hub.ui.debug
 
+import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
 import dagger.multibindings.Multibinds
 
 @Module
@@ -10,4 +12,10 @@ import dagger.multibindings.Multibinds
 abstract class DebugLogModule {
     @Multibinds
     abstract fun bindDebugLogProviders(): Set<DebugLogProvider>
+
+    @Binds
+    @IntoSet
+    abstract fun bindConnectionLogProvider(
+        provider: ConnectionLogProviderImpl
+    ): DebugLogProvider
 }

--- a/hub/src/main/java/io/texne/g1/hub/ui/debug/DebugViewModel.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/debug/DebugViewModel.kt
@@ -394,7 +394,31 @@ class DebugViewModel @Inject constructor(
                         rightStatus = glasses.right.status,
                         rightBattery = glasses.right.batteryPercentage,
                         signalStrength = glasses.signalStrength,
-                        rssi = glasses.rssi
+                        rssi = glasses.rssi,
+                        leftMac = glasses.leftMacAddress,
+                        rightMac = glasses.rightMacAddress,
+                        leftMtu = glasses.leftNegotiatedMtu,
+                        rightMtu = glasses.rightNegotiatedMtu,
+                        leftLastAttempt = glasses.leftLastConnectionAttemptMillis,
+                        rightLastAttempt = glasses.rightLastConnectionAttemptMillis,
+                        leftLastSuccess = glasses.leftLastConnectionSuccessMillis,
+                        rightLastSuccess = glasses.rightLastConnectionSuccessMillis,
+                        leftLastDisconnect = glasses.leftLastDisconnectMillis,
+                        rightLastDisconnect = glasses.rightLastDisconnectMillis,
+                        lastAttempt = glasses.lastConnectionAttemptMillis,
+                        lastSuccess = glasses.lastConnectionSuccessMillis,
+                        lastDisconnect = glasses.lastDisconnectMillis
+                    )
+                },
+                lastConnectedId = it.lastConnectedId,
+                scanTriggers = it.scanTriggerTimestamps,
+                recentScanResults = it.recentScanResults.map { result ->
+                    DebugSnapshot.ServiceSnapshot.ScanResult(
+                        id = result.id,
+                        name = result.name,
+                        signalStrength = result.signalStrength,
+                        rssi = result.rssi,
+                        timestampMillis = result.timestampMillis
                     )
                 }
             )

--- a/hub/src/test/java/io/texne/g1/hub/model/RepositoryTest.kt
+++ b/hub/src/test/java/io/texne/g1/hub/model/RepositoryTest.kt
@@ -41,6 +41,7 @@ class RepositoryTest {
     @BeforeTest
     fun setUp() {
         MockKAnnotations.init(this, relaxUnitFun = true)
+        every { context.applicationContext } returns context
         every { service.listConnectedGlasses() } returns listOf(connectedGlasses)
         repository = Repository(context)
         repository.setServiceManagerForTest(service)

--- a/service/src/main/java/io/texne/g1/basis/service/logging/ConnectionLogStore.kt
+++ b/service/src/main/java/io/texne/g1/basis/service/logging/ConnectionLogStore.kt
@@ -1,0 +1,56 @@
+package io.texne.g1.basis.service.logging
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import org.json.JSONArray
+import org.json.JSONException
+
+private val Context.connectionLogDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "connection_logs"
+)
+
+object ConnectionLogStore {
+    private const val MAX_ENTRIES = 50
+    private val ENTRIES_KEY = stringPreferencesKey("entries")
+
+    suspend fun append(context: Context, entry: String) {
+        context.connectionLogDataStore.edit { preferences ->
+            val entries = decode(preferences[ENTRIES_KEY]).apply { add(entry) }
+            while (entries.size > MAX_ENTRIES) {
+                entries.removeAt(0)
+            }
+            preferences[ENTRIES_KEY] = encode(entries)
+        }
+    }
+
+    suspend fun read(context: Context): List<String> = runCatching {
+        val raw = context.connectionLogDataStore.data
+            .map { preferences -> preferences[ENTRIES_KEY] }
+            .first()
+        decode(raw)
+    }.getOrElse { emptyList() }
+
+    private fun encode(entries: List<String>): String {
+        val json = JSONArray()
+        entries.forEach { json.put(it) }
+        return json.toString()
+    }
+
+    private fun decode(raw: String?): MutableList<String> {
+        if (raw.isNullOrEmpty()) {
+            return mutableListOf()
+        }
+        return try {
+            val array = JSONArray(raw)
+            MutableList(array.length()) { index -> array.optString(index) }
+        } catch (error: JSONException) {
+            mutableListOf()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend the AIDL protocol with per-eye MAC/MTU fields plus recent scan metadata and provide a dedicated scan result parcel
- capture negotiated MTU, connection attempt timing, and scan history in the BLE/device layers, persist connection logs, and surface the data through the service snapshot
- update the client, repository, and debug UI to consume the richer diagnostics, persist scan trigger history, and expose stored connection logs

## Testing
- `./gradlew test` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfbf22db208332b4d0c9a92c265195