### PR TITLE
Add playful connection feedback and required permission

### DIFF
--- a/hub/build.gradle.kts
+++ b/hub/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.hilt.android)
     implementation(libs.hilt.navigation.compose)
+    implementation(libs.nordic.scanner)
     implementation(project(":service"))
     implementation(project(":client"))
     implementation(project(":aidl"))

--- a/hub/src/main/AndroidManifest.xml
+++ b/hub/src/main/AndroidManifest.xml
@@ -2,6 +2,18 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- Android 12+ runtime permissions -->
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_CONNECT"
+        android:usesPermissionFlags="neverForLocation" />
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation" />
+
+    <!-- Legacy location access for pre-Android 12 scanning -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/hub/src/main/java/io/texne/g1/hub/G1HubApplication.kt
+++ b/hub/src/main/java/io/texne/g1/hub/G1HubApplication.kt
@@ -1,14 +1,17 @@
 package io.texne.g1.hub
 
 import android.app.Application
+import android.content.Context
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.HiltAndroidApp
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import io.texne.g1.hub.BuildConfig
 import io.texne.g1.hub.assistant.AssistantActivationGesture
 import io.texne.g1.hub.assistant.AssistantPreferences
+import io.texne.g1.hub.ble.G1Connector
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.StateFlow
 import okhttp3.OkHttpClient
@@ -39,6 +42,12 @@ object GlobalModule {
         assistantPreferences: AssistantPreferences
     ): StateFlow<AssistantActivationGesture> =
         assistantPreferences.observeActivationGesture()
+
+    @Provides
+    @Singleton
+    fun provideG1Connector(
+        @ApplicationContext context: Context
+    ): G1Connector = G1Connector(context)
 }
 
 @HiltAndroidApp

--- a/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
+++ b/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
@@ -1,9 +1,14 @@
 package io.texne.g1.hub
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -12,6 +17,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.core.content.ContextCompat
 import dagger.hilt.android.AndroidEntryPoint
 import io.texne.g1.hub.model.Repository
 import io.texne.g1.hub.ui.ApplicationFrame
@@ -19,14 +25,33 @@ import io.texne.g1.hub.ui.theme.G1HubTheme
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class MainActivity: ComponentActivity() {
+class MainActivity : ComponentActivity() {
+
+    companion object {
+        private const val TAG = "MainActivity"
+    }
+
     @Inject
     lateinit var repository: Repository
+
+    private val bluetoothPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { results ->
+            if (results[Manifest.permission.BLUETOOTH_CONNECT] == false) {
+                Log.w(TAG, "PERM_MISSING=CONNECT")
+            }
+            val scanDenied = results[Manifest.permission.BLUETOOTH_SCAN] == false ||
+                (Build.VERSION.SDK_INT < Build.VERSION_CODES.S &&
+                    results[Manifest.permission.ACCESS_FINE_LOCATION] == false)
+            if (scanDenied) {
+                Log.w(TAG, "PERM_MISSING=SCAN")
+            }
+        }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         repository.bindService()
+        requestBluetoothPermissions()
 
         enableEdgeToEdge()
         setContent {
@@ -47,5 +72,29 @@ class MainActivity: ComponentActivity() {
     override fun onDestroy() {
         super.onDestroy()
         repository.unbindService()
+    }
+
+    private fun requestBluetoothPermissions() {
+        val required = requiredPermissions()
+        if (required.isEmpty()) {
+            return
+        }
+        val missing = required.filter { permission ->
+            ContextCompat.checkSelfPermission(this, permission) != PackageManager.PERMISSION_GRANTED
+        }
+        if (missing.isNotEmpty()) {
+            bluetoothPermissionLauncher.launch(missing.toTypedArray())
+        }
+    }
+
+    private fun requiredPermissions(): Array<String> {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            arrayOf(
+                Manifest.permission.BLUETOOTH_CONNECT,
+                Manifest.permission.BLUETOOTH_SCAN
+            )
+        } else {
+            arrayOf(Manifest.permission.ACCESS_FINE_LOCATION)
+        }
     }
 }

--- a/hub/src/main/java/io/texne/g1/hub/ble/G1Connector.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ble/G1Connector.kt
@@ -1,0 +1,327 @@
+package io.texne.g1.hub.ble
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCallback
+import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothProfile
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.os.ParcelUuid
+import android.util.Log
+import androidx.core.content.ContextCompat
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.texne.g1.basis.client.G1ServiceClient
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import no.nordicsemi.android.support.v18.scanner.BluetoothLeScannerCompat
+import no.nordicsemi.android.support.v18.scanner.ScanCallback
+import no.nordicsemi.android.support.v18.scanner.ScanFilter
+import no.nordicsemi.android.support.v18.scanner.ScanResult as NordicScanResult
+import no.nordicsemi.android.support.v18.scanner.ScanSettings
+
+/**
+ * Implements a three step connection ladder:
+ * 1) Attach to the hub/service if an active connection already exists.
+ * 2) Attempt a bonded connection without scanning.
+ * 3) Fallback to a broad scan followed by a filtered pass.
+ */
+@Singleton
+class G1Connector @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+
+    sealed class Result {
+        data object Success : Result()
+        data object PermissionMissing : Result()
+        data object NotFound : Result()
+    }
+
+    companion object {
+        private const val TAG = "G1Connector"
+        private const val SCAN_PASS_DURATION_MS = 7_000L
+        private const val CONNECT_TIMEOUT_MS = 10_000L
+        private val NUS_UUID: UUID = UUID.fromString("6E400001-B5A3-F393-E0A9-E50E24DCCA9E")
+    }
+
+    suspend fun connectSmart(): Result = withContext(Dispatchers.IO) {
+        if (attachToHub()) {
+            Log.i(TAG, "CONNECT_PATH=HUB")
+            return@withContext Result.Success
+        }
+
+        when (val bonded = tryBondedConnectInternal()) {
+            BondedResult.Success -> {
+                Log.i(TAG, "CONNECT_PATH=BONDED")
+                return@withContext Result.Success
+            }
+            BondedResult.PermissionMissing -> return@withContext Result.PermissionMissing
+            BondedResult.NoDevices -> Unit
+        }
+
+        return@withContext when (val scan = scanAndConnect()) {
+            ScanOutcome.Success -> Result.Success
+            ScanOutcome.PermissionMissing -> Result.PermissionMissing
+            ScanOutcome.NotFound -> Result.NotFound
+        }
+    }
+
+    suspend fun tryBondedConnect(): Result = withContext(Dispatchers.IO) {
+        when (val bonded = tryBondedConnectInternal()) {
+            BondedResult.Success -> {
+                Log.i(TAG, "CONNECT_PATH=BONDED")
+                Result.Success
+            }
+            BondedResult.PermissionMissing -> Result.PermissionMissing
+            BondedResult.NoDevices -> Result.NotFound
+        }
+    }
+
+    private fun attachToHub(): Boolean {
+        return try {
+            val client = G1ServiceClient.open(context) ?: return false
+            val connected = runCatching { client.listConnectedGlasses() }
+                .getOrDefault(emptyList())
+            val success = connected.isNotEmpty()
+            Log.i(TAG, "attachToHub connected=${connected.size}")
+            client.close()
+            success
+        } catch (error: Throwable) {
+            Log.w(TAG, "attachToHub error", error)
+            false
+        }
+    }
+
+    private suspend fun tryBondedConnectInternal(): BondedResult = withContext(Dispatchers.IO) {
+        if (!ensurePermission(Manifest.permission.BLUETOOTH_CONNECT, "CONNECT")) {
+            return@withContext BondedResult.PermissionMissing
+        }
+        val manager = context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+        val adapter = manager?.adapter ?: BluetoothAdapter.getDefaultAdapter()
+        val bonded = adapter?.bondedDevices.orEmpty().filter { device ->
+            val name = device.name.orEmpty()
+            name.contains("Even", ignoreCase = true) || name.contains("G1", ignoreCase = true)
+        }
+        if (bonded.isEmpty()) {
+            Log.i(TAG, "No bonded Even/G1 devices")
+            return@withContext BondedResult.NoDevices
+        }
+
+        bonded.forEach { device ->
+            Log.i(TAG, "Attempt bonded connect to ${device.name} / ${device.address}")
+            if (connectGattOnce(device)) {
+                return@withContext BondedResult.Success
+            }
+        }
+        BondedResult.NoDevices
+    }
+
+    private fun scanAndConnect(): ScanOutcome {
+        if (ensureScanPermissions() == ScanPermission.Missing) {
+            return ScanOutcome.PermissionMissing
+        }
+
+        Log.i(TAG, "Starting broad scan pass")
+        when (val broad = runScan(emptyList())) {
+            ScanOutcome.Success -> return ScanOutcome.Success
+            ScanOutcome.PermissionMissing -> return broad
+            ScanOutcome.NotFound -> Unit
+        }
+
+        Log.i(TAG, "Broad scan complete, starting filtered pass")
+        val filter = ScanFilter.Builder()
+            .setServiceUuid(ParcelUuid(NUS_UUID))
+            .build()
+        return runScan(listOf(filter))
+    }
+
+    private fun runScan(filters: List<ScanFilter>): ScanOutcome {
+        if (ensureScanPermissions() == ScanPermission.Missing) {
+            return ScanOutcome.PermissionMissing
+        }
+        val scanner = BluetoothLeScannerCompat.getScanner()
+        val settings = ScanSettings.Builder()
+            .setLegacy(false)
+            .setReportDelay(0)
+            .setScanMode(ScanSettings.SCAN_MODE_BALANCED)
+            .build()
+        val handler = Handler(Looper.getMainLooper())
+        val latch = CountDownLatch(1)
+        val processed = AtomicBoolean(false)
+        var result: ScanOutcome = ScanOutcome.NotFound
+
+        lateinit var stopRunnable: Runnable
+
+        val callback = object : ScanCallback() {
+            override fun onScanResult(callbackType: Int, scanResult: NordicScanResult) {
+                handleResult(scanResult)
+            }
+
+            override fun onBatchScanResults(results: MutableList<NordicScanResult>) {
+                results.forEach(::handleResult)
+            }
+
+            override fun onScanFailed(errorCode: Int) {
+                Log.w(TAG, "scan failed code=$errorCode")
+                if (processed.compareAndSet(false, true)) {
+                    result = ScanOutcome.NotFound
+                    latch.countDown()
+                }
+            }
+
+            private fun handleResult(resultItem: NordicScanResult) {
+                val device = resultItem.device ?: return
+                val name = device.name ?: resultItem.scanRecord?.deviceName ?: return
+                if (!name.contains("Even", ignoreCase = true) && !name.contains("G1", ignoreCase = true)) {
+                    return
+                }
+                if (!processed.compareAndSet(false, true)) {
+                    return
+                }
+                Log.i(TAG, "scan hit ${name} / ${device.address}")
+                runCatching { scanner.stopScan(this) }
+                handler.removeCallbacks(stopRunnable)
+                result = if (connectGattOnce(device)) {
+                    Log.i(TAG, "CONNECT_PATH=SCAN")
+                    ScanOutcome.Success
+                } else {
+                    ScanOutcome.NotFound
+                }
+                latch.countDown()
+            }
+        }
+
+        stopRunnable = Runnable {
+            if (processed.compareAndSet(false, true)) {
+                Log.i(TAG, "scan window elapsed")
+                runCatching { scanner.stopScan(callback) }
+                result = ScanOutcome.NotFound
+                latch.countDown()
+            }
+        }
+
+        return try {
+            scanner.startScan(filters, settings, callback)
+            handler.postDelayed(stopRunnable, SCAN_PASS_DURATION_MS)
+            latch.await(SCAN_PASS_DURATION_MS + CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            handler.removeCallbacks(stopRunnable)
+            runCatching { scanner.stopScan(callback) }
+            result
+        } catch (error: SecurityException) {
+            Log.w(TAG, "Unable to start BLE scan", error)
+            ScanOutcome.PermissionMissing
+        } catch (error: IllegalStateException) {
+            Log.w(TAG, "BLE scanner unavailable", error)
+            ScanOutcome.NotFound
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun connectGattOnce(device: BluetoothDevice): Boolean {
+        if (!ensurePermission(Manifest.permission.BLUETOOTH_CONNECT, "CONNECT")) {
+            return false
+        }
+        var success = false
+        val latch = CountDownLatch(1)
+        val completed = AtomicBoolean(false)
+
+        val callback = object : BluetoothGattCallback() {
+            override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
+                Log.i(TAG, "onConnectionStateChange status=$status state=$newState")
+                if (status != BluetoothGatt.GATT_SUCCESS && newState == BluetoothProfile.STATE_DISCONNECTED) {
+                    Log.w(TAG, "GATT_STATUS=$status")
+                }
+                if (newState == BluetoothProfile.STATE_CONNECTED) {
+                    gatt.requestMtu(185)
+                    gatt.discoverServices()
+                } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
+                    if (completed.compareAndSet(false, true)) {
+                        runCatching { gatt.close() }
+                        latch.countDown()
+                    }
+                }
+            }
+
+            override fun onMtuChanged(gatt: BluetoothGatt, mtu: Int, status: Int) {
+                Log.i(TAG, "MTU=$mtu status=$status")
+            }
+
+            override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
+                val nus = gatt.getService(NUS_UUID)
+                Log.i(TAG, "NUS present? ${nus != null}")
+                if (status != BluetoothGatt.GATT_SUCCESS) {
+                    Log.w(TAG, "GATT_STATUS=$status")
+                }
+                success = status == BluetoothGatt.GATT_SUCCESS && nus != null
+                if (completed.compareAndSet(false, true)) {
+                    latch.countDown()
+                }
+            }
+        }
+
+        return try {
+            device.connectGatt(context, /* autoConnect = */ false, callback)
+            val awaited = latch.await(CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            if (!awaited) {
+                Log.w(TAG, "connectGattOnce timeout for ${device.address}")
+            }
+            success
+        } catch (error: Throwable) {
+            Log.w(TAG, "connectGattOnce error", error)
+            false
+        }
+    }
+
+    private fun ensureScanPermissions(): ScanPermission {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val scan = ensurePermission(Manifest.permission.BLUETOOTH_SCAN, "SCAN")
+            val connect = ensurePermission(Manifest.permission.BLUETOOTH_CONNECT, "CONNECT")
+            if (scan && connect) ScanPermission.Granted else ScanPermission.Missing
+        } else {
+            if (ensurePermission(Manifest.permission.ACCESS_FINE_LOCATION, "SCAN")) {
+                ScanPermission.Granted
+            } else {
+                ScanPermission.Missing
+            }
+        }
+    }
+
+    private fun ensurePermission(permission: String, marker: String): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S &&
+            (permission == Manifest.permission.BLUETOOTH_CONNECT || permission == Manifest.permission.BLUETOOTH_SCAN)
+        ) {
+            return true
+        }
+        val granted = ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+        if (!granted) {
+            Log.w(TAG, "PERM_MISSING=$marker")
+        }
+        return granted
+    }
+
+    private enum class ScanPermission { Granted, Missing }
+
+    private sealed class BondedResult {
+        data object Success : BondedResult()
+        data object NoDevices : BondedResult()
+        data object PermissionMissing : BondedResult()
+    }
+
+    private sealed class ScanOutcome {
+        data object Success : ScanOutcome()
+        data object NotFound : ScanOutcome()
+        data object PermissionMissing : ScanOutcome()
+    }
+}

--- a/hub/src/main/java/io/texne/g1/hub/ui/ApplicationFrame.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/ApplicationFrame.kt
@@ -46,6 +46,7 @@ fun ApplicationFrame(snackbarHostState: SnackbarHostState) {
                     "Auto-connecting to ${message.glassesName}"
                 is ApplicationViewModel.UiMessage.AutoConnectFailed ->
                     "Auto-connect failed for ${message.glassesName}"
+                is ApplicationViewModel.UiMessage.Snackbar -> message.text
             }
             snackbarHostState.showSnackbar(text)
         }
@@ -75,11 +76,15 @@ fun ApplicationFrame(snackbarHostState: SnackbarHostState) {
                         serviceStatus = state.serviceStatus,
                         nearbyGlasses = state.nearbyGlasses,
                         retryCountdowns = state.retryCountdowns,
+                        connectionFeedback = state.connectionFeedback,
+                        statusMessage = state.statusMessage,
+                        errorMessage = state.errorMessage,
                         scan = { viewModel.scan() },
                         connect = { viewModel.connect(it) },
                         disconnect = { viewModel.disconnect(it) },
                         cancelRetry = { viewModel.cancelAutoRetry(it) },
-                        retryNow = { viewModel.retryNow(it) }
+                        retryNow = { viewModel.retryNow(it) },
+                        onBondedConnect = { viewModel.tryBondedConnect() }
                     )
                 }
             }

--- a/hub/src/main/res/drawable/cat_with_glasses.xml
+++ b/hub/src/main/res/drawable/cat_with_glasses.xml
@@ -1,0 +1,59 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="160dp"
+    android:height="160dp"
+    android:viewportWidth="120"
+    android:viewportHeight="120">
+    <path
+        android:fillColor="#FFE082"
+        android:pathData="M60,16 L78,8 L90,28 Q100,38 104,52 Q108,70 102,86 Q92,108 60,110 Q28,108 18,86 Q12,70 16,52 Q20,38 30,28 L42,8 Z" />
+    <path
+        android:fillColor="#FFF3E0"
+        android:pathData="M60,28 C42,28 28,44 28,64 C28,86 42,104 60,104 C78,104 92,86 92,64 C92,44 78,28 60,28 Z" />
+    <path
+        android:fillColor="#FFCC80"
+        android:pathData="M36,34 L30,24 L42,14 L44,34 Z" />
+    <path
+        android:fillColor="#FFCC80"
+        android:pathData="M84,34 L78,14 L90,24 L84,34 Z" />
+    <path
+        android:fillColor="#5D4037"
+        android:pathData="M60,70 L66,78 L54,78 Z" />
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#5D4037"
+        android:strokeLineCap="round"
+        android:strokeWidth="3"
+        android:pathData="M54,82 C50,84 46,84 42,80" />
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#5D4037"
+        android:strokeLineCap="round"
+        android:strokeWidth="3"
+        android:pathData="M66,82 C70,84 74,84 78,80" />
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#3E2723"
+        android:strokeWidth="4"
+        android:pathData="M32,60 L52,60" />
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#3E2723"
+        android:strokeWidth="4"
+        android:pathData="M68,60 L88,60" />
+    <path
+        android:fillColor="#B3E5FC"
+        android:strokeColor="#3E2723"
+        android:strokeWidth="4"
+        android:pathData="M40,60 m -16,0 a16,16 0 1,0 32,0 a16,16 0 1,0 -32,0" />
+    <path
+        android:fillColor="#B3E5FC"
+        android:strokeColor="#3E2723"
+        android:strokeWidth="4"
+        android:pathData="M80,60 m -16,0 a16,16 0 1,0 32,0 a16,16 0 1,0 -32,0" />
+    <path
+        android:fillColor="#3E2723"
+        android:pathData="M40,60 m -4,0 a4,4 0 1,0 8,0 a4,4 0 1,0 -8,0" />
+    <path
+        android:fillColor="#3E2723"
+        android:pathData="M80,60 m -4,0 a4,4 0 1,0 8,0 a4,4 0 1,0 -8,0" />
+</vector>

--- a/hub/src/main/res/drawable/cat_without_glasses.xml
+++ b/hub/src/main/res/drawable/cat_without_glasses.xml
@@ -1,0 +1,63 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="160dp"
+    android:height="160dp"
+    android:viewportWidth="120"
+    android:viewportHeight="120">
+    <path
+        android:fillColor="#FFE082"
+        android:pathData="M60,16 L78,8 L90,28 Q100,38 104,52 Q108,70 102,86 Q92,108 60,110 Q28,108 18,86 Q12,70 16,52 Q20,38 30,28 L42,8 Z" />
+    <path
+        android:fillColor="#FFF3E0"
+        android:pathData="M60,28 C42,28 28,44 28,64 C28,86 42,104 60,104 C78,104 92,86 92,64 C92,44 78,28 60,28 Z" />
+    <path
+        android:fillColor="#FFCC80"
+        android:pathData="M36,34 L30,24 L42,14 L44,34 Z" />
+    <path
+        android:fillColor="#FFCC80"
+        android:pathData="M84,34 L78,14 L90,24 L84,34 Z" />
+    <path
+        android:fillColor="#5D4037"
+        android:pathData="M60,70 L66,78 L54,78 Z" />
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#3E2723"
+        android:strokeLineCap="round"
+        android:strokeWidth="4"
+        android:pathData="M28,58 Q40,68 52,58" />
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#3E2723"
+        android:strokeLineCap="round"
+        android:strokeWidth="4"
+        android:pathData="M68,58 Q80,68 92,58" />
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#5D4037"
+        android:strokeLineCap="round"
+        android:strokeWidth="3"
+        android:pathData="M52,88 Q60,80 68,88" />
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#5D4037"
+        android:strokeLineCap="round"
+        android:strokeWidth="3"
+        android:pathData="M38,76 L22,74" />
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#5D4037"
+        android:strokeLineCap="round"
+        android:strokeWidth="3"
+        android:pathData="M82,76 L98,74" />
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#5D4037"
+        android:strokeLineCap="round"
+        android:strokeWidth="3"
+        android:pathData="M40,84 L24,88" />
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#5D4037"
+        android:strokeLineCap="round"
+        android:strokeWidth="3"
+        android:pathData="M80,84 L96,88" />
+</vector>


### PR DESCRIPTION
## Summary
- add a connection feedback state in the view model that auto-clears and feeds success, failure, or permission guidance
- refresh the scanner screen to show the cat feedback card, hide stale empty-state messaging after success, and keep existing status/error flows when needed
- supply vector artwork for the cat states and declare INTERNET permission so API-key requests stop failing

## Testing
- ./gradlew :hub:assembleDebug *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc28095e88332932e25b58e4cc79c