### PR TITLE
Make hub pages scrollable

### DIFF
--- a/hub/src/main/java/io/texne/g1/hub/ui/chat/ChatScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/chat/ChatScreen.kt
@@ -123,109 +123,118 @@ private fun ChatContent(
         }
     }
 
+    val pageScrollState = rememberScrollState()
+
     Column(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
+        modifier = modifier.fillMaxSize()
     ) {
-        Text(
-            text = "ChatGPT Assistant",
-            style = MaterialTheme.typography.titleLarge,
-            fontWeight = FontWeight.Bold
-        )
-
-        ConnectionStatus(connectedGlassesName)
-
-        if (!state.apiKeyAvailable) {
-            ApiKeyWarningCard(onNavigateToSettings = onNavigateToSettings)
-        }
-
-        PersonaSelector(
-            personas = state.availablePersonas,
-            selected = state.selectedPersona,
-            onPersonaSelected = onPersonaSelected
-        )
-
-        TodoHudPanel(
-            state = todoState,
-            onToggleTask = onToggleTask,
-            onMoveTaskUp = onMoveTaskUp,
-            onMoveTaskDown = onMoveTaskDown,
-            onDisplayModeSelected = onDisplayModeSelected,
-            onExpandTask = onExpandTask,
-            onCollapseExpanded = onCollapseExpanded,
-            onNextPage = onNextTodoPage,
-            onPreviousPage = onPreviousTodoPage,
-            onClearHudError = onClearTodoHudError
-        )
-
-        if (state.errorMessage != null) {
-            ErrorCard(message = state.errorMessage, onDismiss = onDismissError)
-        }
-
-        when (val hudStatus = state.hudStatus) {
-            is ChatViewModel.HudStatus.DisplayFailed -> {
-                HudStatusCard(
-                    text = "Unable to display response on the HUD. Check the connection and try again.",
-                    highlight = true,
-                    onDismiss = onHudStatusConsumed
-                )
-            }
-            is ChatViewModel.HudStatus.Displayed -> {
-                val message = when {
-                    hudStatus.pageCount > 1 && hudStatus.truncated ->
-                        "Response paginated across ${hudStatus.pageCount} HUD pages (trimmed to fit width)."
-                    hudStatus.pageCount > 1 ->
-                        if (hudStatus.pageCount == 2) {
-                            "Response paginated across 2 HUD pages."
-                        } else {
-                            "Response paginated across ${hudStatus.pageCount} HUD pages."
-                        }
-                    hudStatus.truncated ->
-                        "Response shown on the HUD (trimmed to fit)."
-                    else ->
-                        "Response sent to the HUD."
-                }
-                HudStatusCard(text = message, onDismiss = onHudStatusConsumed)
-            }
-            ChatViewModel.HudStatus.Idle -> Unit
-        }
-
-        Card(
+        Column(
             modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f),
-            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+                .weight(1f)
+                .verticalScroll(pageScrollState)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            if (state.isSending) {
-                LoadingIndicator()
+            Text(
+                text = "ChatGPT Assistant",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold
+            )
+
+            ConnectionStatus(connectedGlassesName)
+
+            if (!state.apiKeyAvailable) {
+                ApiKeyWarningCard(onNavigateToSettings = onNavigateToSettings)
             }
-            LazyColumn(
-                state = listState,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(12.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                if (state.messages.isEmpty()) {
-                    item {
-                        Text(
-                            text = "Ask anything to get started.",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
+
+            PersonaSelector(
+                personas = state.availablePersonas,
+                selected = state.selectedPersona,
+                onPersonaSelected = onPersonaSelected
+            )
+
+            TodoHudPanel(
+                state = todoState,
+                onToggleTask = onToggleTask,
+                onMoveTaskUp = onMoveTaskUp,
+                onMoveTaskDown = onMoveTaskDown,
+                onDisplayModeSelected = onDisplayModeSelected,
+                onExpandTask = onExpandTask,
+                onCollapseExpanded = onCollapseExpanded,
+                onNextPage = onNextTodoPage,
+                onPreviousPage = onPreviousTodoPage,
+                onClearHudError = onClearTodoHudError
+            )
+
+            if (state.errorMessage != null) {
+                ErrorCard(message = state.errorMessage, onDismiss = onDismissError)
+            }
+
+            when (val hudStatus = state.hudStatus) {
+                is ChatViewModel.HudStatus.DisplayFailed -> {
+                    HudStatusCard(
+                        text = "Unable to display response on the HUD. Check the connection and try again.",
+                        highlight = true,
+                        onDismiss = onHudStatusConsumed
+                    )
+                }
+                is ChatViewModel.HudStatus.Displayed -> {
+                    val message = when {
+                        hudStatus.pageCount > 1 && hudStatus.truncated ->
+                            "Response paginated across ${hudStatus.pageCount} HUD pages (trimmed to fit width)."
+                        hudStatus.pageCount > 1 ->
+                            if (hudStatus.pageCount == 2) {
+                                "Response paginated across 2 HUD pages."
+                            } else {
+                                "Response paginated across ${hudStatus.pageCount} HUD pages."
+                            }
+                        hudStatus.truncated ->
+                            "Response shown on the HUD (trimmed to fit)."
+                        else ->
+                            "Response sent to the HUD."
                     }
-                } else {
-                    items(state.messages, key = { it.id }) { message ->
-                        MessageBubble(message = message)
+                    HudStatusCard(text = message, onDismiss = onHudStatusConsumed)
+                }
+                ChatViewModel.HudStatus.Idle -> Unit
+            }
+
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = 240.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+            ) {
+                if (state.isSending) {
+                    LoadingIndicator()
+                }
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(12.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    if (state.messages.isEmpty()) {
+                        item {
+                            Text(
+                                text = "Ask anything to get started.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    } else {
+                        items(state.messages, key = { it.id }) { message ->
+                            MessageBubble(message = message)
+                        }
                     }
                 }
             }
         }
 
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 16.dp),
             verticalAlignment = Alignment.Bottom,
             horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {

--- a/hub/src/main/java/io/texne/g1/hub/ui/glasses/GlassesScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/glasses/GlassesScreen.kt
@@ -10,11 +10,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
@@ -37,23 +38,25 @@ fun GlassesScreen(
     glasses: GlassesSnapshot,
     disconnect: () -> Unit
 ) {
-    Box(
-        Modifier.fillMaxSize()
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
             .padding(start = 16.dp, end = 16.dp, bottom = 16.dp)
+            .verticalScroll(rememberScrollState())
     ) {
         Box(
-            Modifier.fillMaxSize()
+            Modifier
+                .fillMaxWidth()
                 .background(Color.White, RoundedCornerShape(16.dp))
         ) {
             Column(
-                Modifier
+                modifier = Modifier
                     .fillMaxWidth()
-                    .aspectRatio(2.5f)
                     .padding(16.dp),
-                verticalArrangement = Arrangement.SpaceBetween
+                verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
                 Row(
-                    Modifier.fillMaxWidth(),
+                    modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Box(Modifier.weight(1f)) {
@@ -65,7 +68,9 @@ fun GlassesScreen(
                         )
                     }
                     Box(
-                        Modifier.weight(1f).padding(8.dp),
+                        Modifier
+                            .weight(1f)
+                            .padding(8.dp),
                         contentAlignment = Alignment.CenterEnd
                     ) {
                         Button(

--- a/hub/src/main/java/io/texne/g1/hub/ui/settings/SettingsScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/settings/SettingsScreen.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Visibility
@@ -51,6 +53,7 @@ fun SettingsScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
+            .verticalScroll(rememberScrollState())
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {

--- a/subtitles/src/main/java/io/texne/g1/subtitles/ui/SubtitlesScreen.kt
+++ b/subtitles/src/main/java/io/texne/g1/subtitles/ui/SubtitlesScreen.kt
@@ -11,9 +11,12 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Mic
@@ -44,7 +47,10 @@ fun SubtitlesScreen(
     val state = viewModel.state.collectAsState().value
 
     Column(
-        modifier = Modifier.fillMaxSize().padding(32.dp),
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(32.dp),
         verticalArrangement = Arrangement.spacedBy(32.dp)
     ) {
         Box(
@@ -101,9 +107,17 @@ fun SubtitlesScreen(
                 }
             }
             Box(
-                modifier = Modifier.fillMaxSize().border(1.dp, Color.White, RoundedCornerShape(16.dp)).weight(1f)
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = 240.dp)
+                    .border(1.dp, Color.White, RoundedCornerShape(16.dp))
             ) {
-                Column(modifier = Modifier.padding(32.dp).fillMaxSize(), verticalArrangement = Arrangement.Bottom) {
+                Column(
+                    modifier = Modifier
+                        .padding(32.dp)
+                        .fillMaxSize(),
+                    verticalArrangement = Arrangement.Bottom
+                ) {
                     state.displayText.forEach {
                         Text(it, color = Color.Green)
                     }


### PR DESCRIPTION
## Summary
- make the settings tab vertically scrollable so longer content fits on screen
- update the assistant, glasses, and subtitles screens to place their primary content inside scrollable containers

## Testing
- ./gradlew lint *(fails: SDK location not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cff35366948332ae3a136621dc084b