### PR TITLE
Fix ApplicationViewModel state reducer lambda signature

### DIFF
--- a/hub/src/main/java/io/texne/g1/hub/ui/ApplicationViewModel.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/ApplicationViewModel.kt
@@ -123,7 +123,12 @@ class ApplicationViewModel @Inject constructor(
         retryCountdowns,
         retryCounts,
         statusAndError
-    ) { serviceState, section, retries, retryStats, statusAndErrorPair ->
+    ) { args ->
+        val serviceState = args.getOrNull(0) as? Repository.ServiceSnapshot
+        val section = args.getOrNull(1) as? AppSection ?: AppSection.GLASSES
+        val retries = args.getOrNull(2) as? Map<String, RetryCountdown> ?: emptyMap()
+        val retryStats = args.getOrNull(3) as? Map<String, Int> ?: emptyMap()
+        val statusAndErrorPair = args.getOrNull(4) as? Pair<String?, String?> ?: (null to null)
         val (statusText, errorText) = statusAndErrorPair
         State(
             connectedGlasses = serviceState?.glasses?.firstOrNull { it.status == G1ServiceCommon.GlassesStatus.CONNECTED },


### PR DESCRIPTION
## Summary
- update the ApplicationViewModel `combine` reducer to accept the array-based signature expected by the current coroutines overload
- safely unpack the combined flow values before building the view state

## Testing
- `./gradlew :hub:compileDebugKotlin` *(fails: Android SDK is not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d00d567cdc833294dd009933024578