### PR TITLE
Replace getDefaultAdapter() with BluetoothManager adapter

### DIFF
--- a/client/src/main/java/io/texne/g1/basis/client/G1ServiceClient.kt
+++ b/client/src/main/java/io/texne/g1/basis/client/G1ServiceClient.kt
@@ -1,7 +1,6 @@
 package io.texne.g1.basis.client
 
 import android.annotation.SuppressLint
-import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothManager
 import android.content.ComponentName
@@ -115,7 +114,7 @@ class G1ServiceClient private constructor(context: Context): G1ServiceCommon<IG1
         }
 
         val bluetoothManager = context.getSystemService(BluetoothManager::class.java)
-        val adapter = bluetoothManager?.adapter ?: BluetoothAdapter.getDefaultAdapter()
+        val adapter = bluetoothManager?.adapter
         val bondedDevices = try {
             adapter?.bondedDevices ?: emptySet()
         } catch (_: SecurityException) {

--- a/core/src/main/java/io/texne/g1/basis/core/G1.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/G1.kt
@@ -1,8 +1,8 @@
 package io.texne.g1.basis.core
 
 import android.annotation.SuppressLint
-import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothManager
 import android.content.Context
 import android.os.Handler
 import android.os.Looper
@@ -471,6 +471,7 @@ class G1 {
         }
 
         fun find(
+            context: Context,
             duration: Duration,
             sideFilter: Set<G1Gesture.Side>? = null
         ) = callbackFlow<G1?> {
@@ -484,8 +485,9 @@ class G1 {
             val foundAddresses = mutableListOf<String>()
             val foundPairs = mutableMapOf<String, FoundPair>()
 
+            val bluetoothManager = context.getSystemService(BluetoothManager::class.java)
             val bondedDevices = try {
-                BluetoothAdapter.getDefaultAdapter()?.bondedDevices ?: emptySet()
+                bluetoothManager?.adapter?.bondedDevices ?: emptySet()
             } catch (error: SecurityException) {
                 Log.w("G1", "Unable to access bonded devices", error)
                 emptySet()

--- a/hub/src/main/java/io/texne/g1/hub/ble/G1Connector.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ble/G1Connector.kt
@@ -2,7 +2,6 @@ package io.texne.g1.hub.ble
 
 import android.Manifest
 import android.annotation.SuppressLint
-import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothGatt
 import android.bluetooth.BluetoothGattCallback
@@ -109,7 +108,7 @@ class G1Connector @Inject constructor(
             return@withContext BondedResult.PermissionMissing
         }
         val manager = context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
-        val adapter = manager?.adapter ?: BluetoothAdapter.getDefaultAdapter()
+        val adapter = manager?.adapter
         val bonded = adapter?.bondedDevices.orEmpty().filter { device ->
             val name = device.name.orEmpty()
             name.contains("Even", ignoreCase = true) || name.contains("G1", ignoreCase = true)

--- a/hub/src/main/java/io/texne/g1/hub/ui/debug/DebugViewModel.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/debug/DebugViewModel.kt
@@ -3,7 +3,6 @@ package io.texne.g1.hub.ui.debug
 import android.Manifest
 import android.annotation.SuppressLint
 import android.app.Application
-import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothManager
 import android.content.ClipData
 import android.content.ClipboardManager
@@ -339,7 +338,7 @@ class DebugViewModel @Inject constructor(
     @SuppressLint("MissingPermission")
     private fun loadBluetoothInfo(): DebugSnapshot.BluetoothInfo {
         val manager = ContextCompat.getSystemService(application, BluetoothManager::class.java)
-        val adapter = manager?.adapter ?: BluetoothAdapter.getDefaultAdapter()
+        val adapter = manager?.adapter
         if (adapter == null) {
             return DebugSnapshot.BluetoothInfo(
                 enabled = null,

--- a/service/src/main/java/io/texne/g1/basis/service/G1Service.kt
+++ b/service/src/main/java/io/texne/g1/basis/service/G1Service.kt
@@ -302,7 +302,7 @@ class G1Service: Service() {
                     }
 
                     try {
-                        G1.find(15.toDuration(DurationUnit.SECONDS), filterSnapshot).collect { found ->
+                        G1.find(this@G1Service, 15.toDuration(DurationUnit.SECONDS), filterSnapshot).collect { found ->
                             if(found != null) {
                                 Log.d("G1Service", "SCANNING FOUND = ${found}")
 


### PR DESCRIPTION
## Summary
- Acquire Bluetooth adapters via BluetoothManager across client, hub, and core modules to avoid null default adapters
- Update `G1.find` to accept a `Context` so bonded device discovery relies on `BluetoothManager`
- Pass the service context when triggering scans to match the new API

## Testing
- ./gradlew lint *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d294ee7ec883329361b12fe6871896