### PR TITLE
Ensure deterministic initial BLE connection

### DIFF
--- a/core/src/main/java/io/texne/g1/basis/core/G1Device.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/G1Device.kt
@@ -121,7 +121,9 @@ internal class G1Device(
         }
         try {
             manager.connect(device)
-                .useAutoConnect(true)
+                // Deterministic first-time connection; autoConnect(true) can be used by
+                // background reconnection flows when an active session already exists.
+                .useAutoConnect(false)
                 .retry(3)
                 .timeout(30_000)
                 .suspend()


### PR DESCRIPTION
## Summary
- ensure the initial G1Device BLE connection uses direct auto connect to avoid waiting for background advertisements

## Testing
- ./gradlew :core:lint *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d29b323bcc8332a732be1f9ca6e546