### PR TITLE
Improve BLE session promotion to G1BLEManager

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -34,6 +34,7 @@ android {
 
 dependencies {
     // BLE
+    api(libs.nordic.ble)
     implementation(libs.nordic.ble.ktx)
     implementation(libs.nordic.ble.common)
     implementation(libs.nordic.scanner)

--- a/core/src/main/java/io/texne/g1/basis/core/G1BLEManager.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/G1BLEManager.kt
@@ -256,7 +256,7 @@ public class G1BLEManager private constructor(
         writableConnectionState.value = G1.ConnectionState.DISCONNECTED
     }
 
-    internal fun connectIfNeeded(device: BluetoothDevice): ConnectRequest? {
+    fun connectIfNeeded(device: BluetoothDevice): ConnectRequest? {
         val address = device.address
         if (!address.isNullOrEmpty()) {
             consumePendingGatt(address)
@@ -267,7 +267,7 @@ public class G1BLEManager private constructor(
         return connect(device)
     }
 
-    internal fun currentGatt(): BluetoothGatt? = deviceGatt
+    fun currentGatt(): BluetoothGatt? = deviceGatt
 
     suspend fun disconnectAndClose() {
         stopHeartbeat()

--- a/core/src/main/java/io/texne/g1/basis/core/G1BLEManager.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/G1BLEManager.kt
@@ -6,16 +6,24 @@ import android.bluetooth.BluetoothGatt
 import android.bluetooth.BluetoothGattCharacteristic
 import android.content.Context
 import android.util.Log
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import no.nordicsemi.android.ble.BleManager
+import no.nordicsemi.android.ble.ConnectRequest
 import no.nordicsemi.android.ble.data.Data
 import no.nordicsemi.android.ble.observer.ConnectionObserver
-import java.util.UUID
+import no.nordicsemi.android.ble.ktx.suspend
 
 private fun Data.toByteArray(): ByteArray {
     val array = ByteArray(this.size())
@@ -37,10 +45,47 @@ private fun BluetoothGattCharacteristic.supportsNotifications(): Boolean =
             BluetoothGattCharacteristic.PROPERTY_INDICATE
         ) != 0
 
-@SuppressLint("MissingPermission")
-internal class G1BLEManager(private val deviceName: String, context: Context, private val coroutineScope: CoroutineScope): BleManager(context) {
+private const val MAX_MTU = 251
+private const val HEARTBEAT_INTERVAL_MS = 28_000L
 
-    private val writableConnectionState = MutableStateFlow<G1.ConnectionState>(G1.ConnectionState.CONNECTING)
+@SuppressLint("MissingPermission")
+public class G1BLEManager private constructor(
+    private val deviceName: String,
+    context: Context,
+    private val deviceAddress: String
+) : BleManager(context.applicationContext) {
+
+    companion object {
+        private val managers = ConcurrentHashMap<String, G1BLEManager>()
+        private val pendingGatts = ConcurrentHashMap<String, BluetoothGatt>()
+
+        fun getOrCreate(device: BluetoothDevice, context: Context): G1BLEManager {
+            val address = device.address
+            require(!address.isNullOrEmpty()) { "Device address required" }
+            return managers.getOrPut(address) {
+                G1BLEManager(device.name ?: address, context.applicationContext, address)
+            }
+        }
+
+        fun attach(gatt: BluetoothGatt) {
+            val address = gatt.device?.address
+            if (!address.isNullOrEmpty()) {
+                pendingGatts[address] = gatt
+            }
+        }
+
+        internal fun consumePendingGatt(address: String): BluetoothGatt? = pendingGatts.remove(address)
+
+        internal fun remove(address: String) {
+            managers.remove(address)
+            pendingGatts.remove(address)
+        }
+    }
+
+    private val scopeJob = SupervisorJob()
+    private val internalScope: CoroutineScope = CoroutineScope(scopeJob + Dispatchers.IO)
+
+    private val writableConnectionState = MutableStateFlow<G1.ConnectionState>(G1.ConnectionState.DISCONNECTED)
     val connectionState = writableConnectionState.asStateFlow()
     private val writableIncoming = MutableSharedFlow<IncomingPacket>()
     val incoming = writableIncoming.asSharedFlow()
@@ -48,10 +93,10 @@ internal class G1BLEManager(private val deviceName: String, context: Context, pr
     private var deviceGatt: BluetoothGatt? = null
     private var writeCharacteristic: BluetoothGattCharacteristic? = null
     private var readCharacteristic: BluetoothGattCharacteristic? = null
+    private var heartbeatJob: Job? = null
 
     override fun initialize() {
-        requestMtu(251)
-            .enqueue()
+        requestMtu(MAX_MTU).enqueue()
         setConnectionObserver(object: ConnectionObserver {
             override fun onDeviceConnecting(device: BluetoothDevice) {
                 writableConnectionState.value = G1.ConnectionState.CONNECTING
@@ -81,6 +126,7 @@ internal class G1BLEManager(private val deviceName: String, context: Context, pr
                 reason: Int
             ) {
                 writableConnectionState.value = G1.ConnectionState.DISCONNECTED
+                stopHeartbeat()
             }
         })
         val notificationCharacteristic = readCharacteristic
@@ -89,21 +135,22 @@ internal class G1BLEManager(private val deviceName: String, context: Context, pr
             return
         }
 
-        setNotificationCallback(
-            notificationCharacteristic
-        ).with { device, data ->
-            val split = device.name.split('_')
+        setNotificationCallback(notificationCharacteristic).with { device, data ->
+            val nameParts = device.name.orEmpty().split('_')
             val packet = IncomingPacket.fromBytes(data.toByteArray())
-            if(packet == null) {
-                Log.d("G1BLEManager", "TRAFFIC_LOG ${split[2]} - ${packet}")
+            if (packet == null) {
+                Log.d("G1BLEManager", "TRAFFIC_LOG ${nameParts.getOrNull(2) ?: "?"} - null")
             } else {
-                Log.d("G1BLEManager", "TRAFFIC_LOG ${split[2]} - ${packet}")
-                coroutineScope.launch {
+                Log.d("G1BLEManager", "TRAFFIC_LOG ${nameParts.getOrNull(2) ?: "?"} - $packet")
+                internalScope.launch {
                     writableIncoming.emit(packet)
                 }
             }
         }
         enableNotifications(notificationCharacteristic)
+            .done {
+                startHeartbeat()
+            }
             .fail { _, status ->
                 Log.e(
                     "G1BLEManager",
@@ -118,6 +165,16 @@ internal class G1BLEManager(private val deviceName: String, context: Context, pr
     fun send(packet: OutgoingPacket): Boolean {
         Log.d("G1BLEManager", "G1_TRAFFIC_SEND ${packet.bytes.map { String.format("%02x", it) }.joinToString(" ")}")
 
+        return writeTx(packet.bytes)
+    }
+
+    fun writeTx(data: ByteArray): Boolean {
+        val characteristic = writeCharacteristic
+        if (characteristic == null) {
+            Log.e("G1BLEManager", "UART write characteristic missing for $deviceName")
+            return false
+        }
+
         var attemptsRemaining = 3
         var success: Boolean = false
         while(!success && attemptsRemaining > 0) {
@@ -126,17 +183,16 @@ internal class G1BLEManager(private val deviceName: String, context: Context, pr
             }
             success = try {
                 writeCharacteristic(
-                    writeCharacteristic!!,
-                    packet.bytes,
+                    characteristic,
+                    data,
                     BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
                 ).await()
                 true
             } catch (e: Exception) {
                 val attemptNumber = 3 - attemptsRemaining
-                val status = writableConnectionState.value
                 Log.e(
                     "G1BLEManager",
-                    "Failed to send packet on attempt $attemptNumber (status=$status): ${e.message}",
+                    "Failed to send packet on attempt $attemptNumber (status=${writableConnectionState.value}): ${e.message}",
                     e
                 )
                 false
@@ -184,6 +240,7 @@ internal class G1BLEManager(private val deviceName: String, context: Context, pr
             readCharacteristic = read
             deviceGatt = gatt
             gatt.setCharacteristicNotification(read, true)
+            attach(gatt)
             logFirmwareServices(gatt)
             return true
         }
@@ -195,7 +252,54 @@ internal class G1BLEManager(private val deviceName: String, context: Context, pr
     override fun onServicesInvalidated() {
         writeCharacteristic = null
         readCharacteristic = null
+        stopHeartbeat()
         writableConnectionState.value = G1.ConnectionState.DISCONNECTED
+    }
+
+    internal fun connectIfNeeded(device: BluetoothDevice): ConnectRequest? {
+        val address = device.address
+        if (!address.isNullOrEmpty()) {
+            consumePendingGatt(address)
+        }
+        if (isConnected) {
+            return null
+        }
+        return connect(device)
+    }
+
+    internal fun currentGatt(): BluetoothGatt? = deviceGatt
+
+    suspend fun disconnectAndClose() {
+        stopHeartbeat()
+        val read = readCharacteristic
+        if (read != null) {
+            runCatching { disableNotifications(read).suspend() }
+                .onFailure { Log.w("G1BLEManager", "disableNotifications failed for $deviceName", it) }
+        }
+        runCatching { disconnect().suspend() }
+            .onFailure { Log.w("G1BLEManager", "disconnect failed for $deviceName", it) }
+        close()
+        scopeJob.cancel()
+        remove(deviceAddress)
+    }
+
+    private fun startHeartbeat() {
+        if (heartbeatJob?.isActive == true) {
+            return
+        }
+        heartbeatJob = internalScope.launch {
+            while (isActive) {
+                delay(HEARTBEAT_INTERVAL_MS)
+                if (!writeTx(byteArrayOf(0x25))) {
+                    Log.w("G1BLEManager", "Failed to send heartbeat for $deviceName")
+                }
+            }
+        }
+    }
+
+    private fun stopHeartbeat() {
+        heartbeatJob?.cancel()
+        heartbeatJob = null
     }
 
     private fun logFirmwareServices(gatt: BluetoothGatt) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ mockk = "1.13.13"
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+nordic-ble = { group = "no.nordicsemi.android", name = "ble", version.ref = "nordicBle" }
 nordic-ble-ktx = { group = "no.nordicsemi.android", name = "ble-ktx", version.ref = "nordicBle" }
 nordic-ble-common = { group = "no.nordicsemi.android", name = "ble-common", version.ref = "nordicBle" }
 nordic-scanner = { group = "no.nordicsemi.android.support.v18", name = "scanner", version.ref = "nordicScanner" }

--- a/hub/build.gradle.kts
+++ b/hub/build.gradle.kts
@@ -66,6 +66,7 @@ dependencies {
     implementation(project(":service"))
     implementation(project(":client"))
     implementation(project(":aidl"))
+    implementation(project(":core"))
     implementation(libs.androidx.security.crypto)
     implementation(libs.okhttp)
     implementation(libs.okhttp.logging)

--- a/hub/build.gradle.kts
+++ b/hub/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.hilt.android)
     implementation(libs.hilt.navigation.compose)
+    implementation(libs.nordic.ble)
     implementation(libs.nordic.scanner)
     implementation(project(":service"))
     implementation(project(":client"))


### PR DESCRIPTION
## Summary
- centralize BLE session management in `G1BLEManager` with a shared registry, heartbeat scheduling, and a raw TX helper
- reuse the managed connection from `G1Device` to avoid reopening GATT links and keep listeners single-registered
- let `G1Connector` hand successful probes to the shared manager and add the core module as a hub dependency to access it

## Testing
- ⚠️ `./gradlew :hub:compileDebugKotlin` *(fails: Android SDK not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d34769a5588332b61461cabb56a332