### PR TITLE
Add BLE diagnostics logging and in-app viewer

### DIFF
--- a/core/src/main/java/io/texne/g1/basis/core/BleLogger.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/BleLogger.kt
@@ -1,0 +1,85 @@
+package io.texne.g1.basis.core
+
+import android.util.Log
+import java.text.SimpleDateFormat
+import java.util.ArrayDeque
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Lightweight in-memory logger for capturing BLE diagnostics that can be surfaced in-app.
+ */
+object BleLogger {
+    private const val MAX_ENTRIES = 500
+
+    private data class LogEntry(
+        val timestampMillis: Long,
+        val priority: Int,
+        val tag: String,
+        val message: String
+    )
+
+    private val entries = ArrayDeque<LogEntry>(MAX_ENTRIES)
+    private val formatter = ThreadLocal.withInitial {
+        SimpleDateFormat("HH:mm:ss.SSS", Locale.US).apply {
+            timeZone = TimeZone.getDefault()
+        }
+    }
+    private val writableLines = MutableStateFlow<List<String>>(emptyList())
+
+    val lines: StateFlow<List<String>> = writableLines.asStateFlow()
+
+    fun log(priority: Int = Log.DEBUG, tag: String, message: String, throwable: Throwable? = null) {
+        val formattedThrowable = throwable?.let { throwableValue ->
+            " (" + throwableValue::class.java.simpleName + ": " + (throwableValue.message ?: "") + ")"
+        }.orEmpty()
+        Log.println(priority, tag, message + (throwable?.let { "\n" + Log.getStackTraceString(it) } ?: ""))
+        val entry = LogEntry(
+            timestampMillis = System.currentTimeMillis(),
+            priority = priority,
+            tag = tag,
+            message = message + formattedThrowable
+        )
+        val snapshot: List<String>
+        synchronized(entries) {
+            entries.addLast(entry)
+            while (entries.size > MAX_ENTRIES) {
+                entries.removeFirst()
+            }
+            snapshot = entries.map { logEntry -> format(logEntry) }
+        }
+        writableLines.value = snapshot
+    }
+
+    fun debug(tag: String, message: String) = log(Log.DEBUG, tag, message)
+
+    fun info(tag: String, message: String) = log(Log.INFO, tag, message)
+
+    fun warn(tag: String, message: String, throwable: Throwable? = null) =
+        log(Log.WARN, tag, message, throwable)
+
+    fun error(tag: String, message: String, throwable: Throwable? = null) =
+        log(Log.ERROR, tag, message, throwable)
+
+    fun latest(limit: Int): List<String> {
+        val snapshot: List<LogEntry> = synchronized(entries) { entries.toList() }
+        return snapshot.takeLast(limit).map { entry -> format(entry) }
+    }
+
+    private fun format(entry: LogEntry): String {
+        val level = when (entry.priority) {
+            Log.ERROR -> "E"
+            Log.WARN -> "W"
+            Log.INFO -> "I"
+            Log.VERBOSE -> "V"
+            Log.ASSERT -> "A"
+            else -> "D"
+        }
+        val timestamp = formatter.get().format(Date(entry.timestampMillis))
+        return "$timestamp $level/${entry.tag}: ${entry.message}"
+    }
+}

--- a/core/src/main/java/io/texne/g1/basis/core/G1BLEManager.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/G1BLEManager.kt
@@ -116,6 +116,13 @@ public class G1BLEManager private constructor(
 
             override fun onDeviceConnected(device: BluetoothDevice) {
                 writableConnectionState.value = G1.ConnectionState.CONNECTED
+                // Request MTU here (185–251)
+                // Enable notifications on NUS RX
+                // Start 0x25 heartbeat scheduler
+            }
+
+            override fun onDeviceReady(device: BluetoothDevice) {
+                // Safe to start GATT operations
             }
 
             override fun onDeviceFailedToConnect(device: BluetoothDevice, reason: Int) {

--- a/core/src/main/java/io/texne/g1/basis/core/G1BLEManager.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/G1BLEManager.kt
@@ -110,33 +110,23 @@ public class G1BLEManager private constructor(
             }
             .enqueue()
         setConnectionObserver(object : ConnectionObserver {
-            override fun onDeviceConnecting(device: BluetoothDevice) {
-                writableConnectionState.value = G1.ConnectionState.CONNECTING
-            }
+            override fun onDeviceConnecting(device: BluetoothDevice) {}
 
             override fun onDeviceConnected(device: BluetoothDevice) {
-                writableConnectionState.value = G1.ConnectionState.CONNECTED
-                // Request MTU here (185–251)
+                // Request MTU (185–251)
                 // Enable notifications on NUS RX
-                // Start 0x25 heartbeat scheduler
+                // Start heartbeat (0x25) scheduler
             }
 
             override fun onDeviceReady(device: BluetoothDevice) {
                 // Safe to start GATT operations
             }
 
-            override fun onDeviceFailedToConnect(device: BluetoothDevice, reason: Int) {
-                writableConnectionState.value = G1.ConnectionState.ERROR
-            }
+            override fun onDeviceFailedToConnect(device: BluetoothDevice, reason: Int) {}
 
-            override fun onDeviceDisconnecting(device: BluetoothDevice) {
-                writableConnectionState.value = G1.ConnectionState.DISCONNECTING
-            }
+            override fun onDeviceDisconnecting(device: BluetoothDevice) {}
 
-            override fun onDeviceDisconnected(device: BluetoothDevice, reason: Int) {
-                writableConnectionState.value = G1.ConnectionState.DISCONNECTED
-                stopHeartbeat()
-            }
+            override fun onDeviceDisconnected(device: BluetoothDevice, reason: Int) {}
         })
         val notificationCharacteristic = readCharacteristic
         if (notificationCharacteristic == null) {

--- a/core/src/main/java/io/texne/g1/basis/core/G1BLEManager.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/G1BLEManager.kt
@@ -113,13 +113,13 @@ public class G1BLEManager private constructor(
             override fun onDeviceConnecting(device: BluetoothDevice) {}
 
             override fun onDeviceConnected(device: BluetoothDevice) {
-                // Request MTU (185–251)
-                // Enable notifications on NUS RX
-                // Start heartbeat (0x25) scheduler
+                // Request MTU here (e.g. requestMtu(251))
+                // Enable notifications on RX characteristic
+                // Start heartbeat (0x25) every 28–30s
             }
 
             override fun onDeviceReady(device: BluetoothDevice) {
-                // Safe to start GATT operations
+                // GATT fully ready, safe to start I/O
             }
 
             override fun onDeviceFailedToConnect(device: BluetoothDevice, reason: Int) {}

--- a/core/src/main/java/io/texne/g1/basis/core/G1BLEManager.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/G1BLEManager.kt
@@ -109,34 +109,24 @@ public class G1BLEManager private constructor(
                 BleLogger.warn("G1BLEManager", "MTU request failed for $deviceName (status=$status)")
             }
             .enqueue()
-        setConnectionObserver(object: ConnectionObserver {
+        setConnectionObserver(object : ConnectionObserver {
             override fun onDeviceConnecting(device: BluetoothDevice) {
                 writableConnectionState.value = G1.ConnectionState.CONNECTING
             }
 
             override fun onDeviceConnected(device: BluetoothDevice) {
-                // EMPTY
-            }
-
-            override fun onDeviceFailedToConnect(
-                device: BluetoothDevice,
-                reason: Int
-            ) {
-                writableConnectionState.value = G1.ConnectionState.ERROR
-            }
-
-            override fun onDeviceReady(device: BluetoothDevice) {
                 writableConnectionState.value = G1.ConnectionState.CONNECTED
+            }
+
+            override fun onDeviceFailedToConnect(device: BluetoothDevice, reason: Int) {
+                writableConnectionState.value = G1.ConnectionState.ERROR
             }
 
             override fun onDeviceDisconnecting(device: BluetoothDevice) {
                 writableConnectionState.value = G1.ConnectionState.DISCONNECTING
             }
 
-            override fun onDeviceDisconnected(
-                device: BluetoothDevice,
-                reason: Int
-            ) {
+            override fun onDeviceDisconnected(device: BluetoothDevice, reason: Int) {
                 writableConnectionState.value = G1.ConnectionState.DISCONNECTED
                 stopHeartbeat()
             }

--- a/hub/src/main/java/io/texne/g1/hub/ui/ApplicationFrame.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/ApplicationFrame.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import io.texne.g1.basis.client.G1ServiceCommon
 import io.texne.g1.hub.permissions.PermissionHelper
+import io.texne.g1.hub.ui.diagnostics.DiagnosticsScreen
 import io.texne.g1.hub.ui.chat.ChatScreen
 import io.texne.g1.hub.ui.settings.SettingsScreen
 import io.texne.g1.hub.ui.telemetry.TelemetryScreen
@@ -157,6 +158,9 @@ fun ApplicationFrame(snackbarHostState: SnackbarHostState) {
                     onNavigateToSettings = { viewModel.selectSection(AppSection.SETTINGS) }
                 )
             }
+            AppSection.DIAGNOSTICS -> {
+                DiagnosticsScreen()
+            }
             AppSection.SETTINGS -> {
                 SettingsScreen()
             }
@@ -216,5 +220,6 @@ enum class AppSection(val label: String) {
     GLASSES("Glasses"),
     TELEMETRY("Telemetry"),
     ASSISTANT("Assistant"),
+    DIAGNOSTICS("Diagnostics"),
     SETTINGS("Settings")
 }

--- a/hub/src/main/java/io/texne/g1/hub/ui/diagnostics/DiagnosticsScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/diagnostics/DiagnosticsScreen.kt
@@ -1,0 +1,74 @@
+package io.texne.g1.hub.ui.diagnostics
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+@Composable
+fun DiagnosticsScreen(
+    modifier: Modifier = Modifier,
+    viewModel: DiagnosticsViewModel = hiltViewModel()
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val scrollState = rememberScrollState()
+    val text = remember(state.lines) { state.lines.joinToString(separator = "\n") }
+
+    LaunchedEffect(state.lines.size) {
+        if (state.lines.isNotEmpty()) {
+            scrollState.scrollTo(scrollState.maxValue)
+        }
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Text(
+            text = "Diagnostics",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "Showing ${state.lines.size} of ${state.maxLines} lines",
+            style = MaterialTheme.typography.bodySmall
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Surface(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+        ) {
+            SelectionContainer {
+                Column(
+                    modifier = Modifier
+                        .verticalScroll(scrollState)
+                        .padding(16.dp)
+                        .fillMaxWidth()
+                ) {
+                    val content = text.ifBlank { "Logs will appear here once events are captured." }
+                    Text(text = content, style = MaterialTheme.typography.bodySmall)
+                }
+            }
+        }
+    }
+}

--- a/hub/src/main/java/io/texne/g1/hub/ui/diagnostics/DiagnosticsViewModel.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/diagnostics/DiagnosticsViewModel.kt
@@ -1,0 +1,38 @@
+package io.texne.g1.hub.ui.diagnostics
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.texne.g1.basis.core.BleLogger
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+@HiltViewModel
+class DiagnosticsViewModel @Inject constructor() : ViewModel() {
+    companion object {
+        private const val MAX_LINES = 200
+    }
+
+    data class State(
+        val lines: List<String> = emptyList(),
+        val maxLines: Int = MAX_LINES
+    )
+
+    val state: StateFlow<State> = BleLogger.lines
+        .map { entries ->
+            val recent = if (entries.size > MAX_LINES) {
+                entries.takeLast(MAX_LINES)
+            } else {
+                entries
+            }
+            State(lines = recent, maxLines = MAX_LINES)
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = State()
+        )
+}


### PR DESCRIPTION
## Summary
- add an in-memory BleLogger that records timestamps, priorities, and tags for BLE diagnostics
- wire new logging through bonding, G1BLEManager, G1Device, and G1Connector to capture permission state, scan selection, connect parameters, and recovery steps
- surface the latest BLE diagnostics with a new Diagnostics tab and screen inside the hub application

## Testing
- ./gradlew :core:compileDebugKotlin :hub:compileDebugKotlin --console=plain *(fails: SDK not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3787269548332a03d9aaac7fa601a