### PR TITLE
Fix service notification intent

### DIFF
--- a/service/src/main/java/io/texne/g1/basis/service/G1Service.kt
+++ b/service/src/main/java/io/texne/g1/basis/service/G1Service.kt
@@ -541,17 +541,28 @@ class G1Service: Service() {
                 getSystemService(NOTIFICATION_SERVICE) as NotificationManager
             notificationManager.createNotificationChannel(notificationChannel)
 
-            val notification = Notification.Builder(this, G1_SERVICE_NOTIFICATION_CHANNEL_ID)
+            val launchIntent = packageManager
+                .getLaunchIntentForPackage(packageName)
+                ?.apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                }
+
+            val notificationBuilder = Notification.Builder(this, G1_SERVICE_NOTIFICATION_CHANNEL_ID)
                 .setSmallIcon(R.mipmap.ic_service_foreground)
                 .setContentTitle(getString(R.string.notification_channel_name))
                 .setContentText(getString(R.string.notification_text))
-                .setContentIntent(
-                    PendingIntent.getActivity(
-                        this, 0, Intent(this, G1Service::class.java),
-                        PendingIntent.FLAG_IMMUTABLE
-                    )
+
+            launchIntent?.let { intent ->
+                val contentIntent = PendingIntent.getActivity(
+                    this,
+                    0,
+                    intent,
+                    PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
                 )
-                .build()
+                notificationBuilder.setContentIntent(contentIntent)
+            }
+
+            val notification = notificationBuilder.build()
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 startForeground(


### PR DESCRIPTION
## Summary
- build the foreground notification intent using the app's launch activity instead of the service class
- avoid crashes when the foreground service creates its notification on startup

## Testing
- `./gradlew test` *(fails: Android SDK is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d404d823308332b55b7df4586c3e71