### PR TITLE
Handle missing service connection gracefully

### DIFF
--- a/subtitles/src/main/java/io/texne/g1/subtitles/ui/SubtitlesScreen.kt
+++ b/subtitles/src/main/java/io/texne/g1/subtitles/ui/SubtitlesScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.MicOff
@@ -47,6 +48,18 @@ fun SubtitlesScreen(
         modifier = Modifier.fillMaxSize().padding(32.dp),
         verticalArrangement = Arrangement.spacedBy(32.dp)
     ) {
+        state.errorMessage?.let { message ->
+            SelectionContainer {
+                Text(
+                    text = message,
+                    color = Color(150, 0, 0, 255),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(Color(0xFFFFE5E5), RoundedCornerShape(12.dp))
+                        .padding(16.dp)
+                )
+            }
+        }
         Box(
             modifier = Modifier.fillMaxWidth().aspectRatio(2f)
         ) {

--- a/subtitles/src/main/java/io/texne/g1/subtitles/ui/SubtitlesViewModel.kt
+++ b/subtitles/src/main/java/io/texne/g1/subtitles/ui/SubtitlesViewModel.kt
@@ -24,7 +24,8 @@ class SubtitlesViewModel @Inject constructor(
         val started: Boolean = false,
         val listening: Boolean = false,
         val displayText: List<String> = listOf(),
-        val queuedText: List<String> = listOf()
+        val queuedText: List<String> = listOf(),
+        val errorMessage: String? = null
     )
 
     private val writableState = MutableStateFlow(State())
@@ -37,7 +38,8 @@ class SubtitlesViewModel @Inject constructor(
                     glasses = it.glasses,
                     hubInstalled = it.hubInstalled,
                     started = it.started,
-                    listening = it.listening
+                    listening = it.listening,
+                    errorMessage = it.errorMessage
                 )
             }
         }


### PR DESCRIPTION
## Summary
- avoid crashes when the G1 service client is unavailable by guarding accesses
- release the service connection safely when the activity stops
- surface a copyable error message when the Basis Hub service cannot be reached

## Testing
- `./gradlew test` *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a8201914833299cceead31cca58e