### PR TITLE
Handle connected device FGS permission

### DIFF
--- a/service/src/main/AndroidManifest.xml
+++ b/service/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <permission android:name="io.texne.g1.basis.permission.CONNECT_TO_SERVICE"/>
     <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+    <!-- Permissions required for connected-device foreground service support -->
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/service/src/main/java/io/texne/g1/basis/service/G1Service.kt
+++ b/service/src/main/java/io/texne/g1/basis/service/G1Service.kt
@@ -565,11 +565,25 @@ class G1Service: Service() {
             val notification = notificationBuilder.build()
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                startForeground(
-                    G1_SERVICE_NOTIFICATION_ID,
-                    notification,
-                    ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
-                )
+                val hasConnectedDevicePermission =
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                        ContextCompat.checkSelfPermission(
+                            this,
+                            Manifest.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE
+                        ) == PackageManager.PERMISSION_GRANTED
+                    } else {
+                        true
+                    }
+
+                if (hasConnectedDevicePermission) {
+                    startForeground(
+                        G1_SERVICE_NOTIFICATION_ID,
+                        notification,
+                        ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
+                    )
+                } else {
+                    startForeground(G1_SERVICE_NOTIFICATION_ID, notification)
+                }
             } else {
                 startForeground(G1_SERVICE_NOTIFICATION_ID, notification)
             }


### PR DESCRIPTION
## Summary
- document the permissions required for the connected-device foreground service in the service manifest
- guard the connected-device foreground service start with a runtime permission check to avoid crashes when the permission is missing

## Testing
- ./gradlew :service:lint *(fails: missing Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4becc7cd48332b0ea2b85aaa01a01