### PR TITLE
Add Bluetooth and foreground service permissions

### DIFF
--- a/client/src/main/AndroidManifest.xml
+++ b/client/src/main/AndroidManifest.xml
@@ -4,4 +4,8 @@
         <package android:name="io.texne.g1.hub" />
     </queries>
     <uses-permission android:name="io.texne.g1.basis.permission.CONNECT_TO_SERVICE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
 </manifest>


### PR DESCRIPTION
## Summary
- add required foreground service and Bluetooth permissions to the client manifest

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4c1e6e990833293043ca7a929096d