### PR TITLE
Request Bluetooth runtime permissions before binding service

### DIFF
--- a/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
+++ b/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
@@ -61,7 +61,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onRequestPermissionsResult(
         requestCode: Int,
-        permissions: Array<out String>,
+        permissions: Array<String>,
         grantResults: IntArray
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)

--- a/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
+++ b/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
@@ -65,7 +65,7 @@ class MainActivity : ComponentActivity() {
         grantResults: IntArray
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        // keep existing logic
+        // keep existing permission handling logic
         if (requestCode != REQUEST_CODE_BLUETOOTH) {
             return
         }

--- a/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
+++ b/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
@@ -65,10 +65,12 @@ class MainActivity : ComponentActivity() {
         grantResults: IntArray
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if (requestCode == REQUEST_CODE_BLUETOOTH) {
-            if (grantResults.isNotEmpty() && grantResults.all { it == PackageManager.PERMISSION_GRANTED }) {
-                repository.bindService()
-            }
+        if (requestCode != REQUEST_CODE_BLUETOOTH) {
+            return
+        }
+
+        if (grantResults.isNotEmpty() && grantResults.all { it == PackageManager.PERMISSION_GRANTED }) {
+            repository.bindService()
         }
     }
 

--- a/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
+++ b/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
@@ -65,12 +65,13 @@ class MainActivity : ComponentActivity() {
         grantResults: IntArray
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        // keep existing permission handling logic
-        if (requestCode != REQUEST_CODE_BLUETOOTH) {
-            return
-        }
 
-        if (grantResults.isNotEmpty() && grantResults.all { it == PackageManager.PERMISSION_GRANTED }) {
+        val bluetoothPermissionsGranted =
+            requestCode == REQUEST_CODE_BLUETOOTH &&
+                grantResults.isNotEmpty() &&
+                grantResults.all { it == PackageManager.PERMISSION_GRANTED }
+
+        if (bluetoothPermissionsGranted) {
             repository.bindService()
         }
     }

--- a/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
+++ b/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
@@ -1,9 +1,14 @@
 package io.texne.g1.hub
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -27,7 +32,11 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        repository.bindService()
+        if (hasBluetoothPermissions()) {
+            repository.bindService()
+        } else {
+            requestBluetoothPermissions()
+        }
 
         enableEdgeToEdge()
         setContent {
@@ -48,5 +57,43 @@ class MainActivity : ComponentActivity() {
     override fun onDestroy() {
         super.onDestroy()
         repository.unbindService()
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode == REQUEST_CODE_BLUETOOTH) {
+            if (grantResults.isNotEmpty() && grantResults.all { it == PackageManager.PERMISSION_GRANTED }) {
+                repository.bindService()
+            }
+        }
+    }
+
+    private fun hasBluetoothPermissions(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            return true
+        }
+
+        return BLUETOOTH_PERMISSIONS.all { permission ->
+            ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED
+        }
+    }
+
+    private fun requestBluetoothPermissions() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            ActivityCompat.requestPermissions(this, BLUETOOTH_PERMISSIONS, REQUEST_CODE_BLUETOOTH)
+        }
+    }
+
+    private companion object {
+        private const val REQUEST_CODE_BLUETOOTH = 0x42
+        private val BLUETOOTH_PERMISSIONS = arrayOf(
+            Manifest.permission.BLUETOOTH_CONNECT,
+            Manifest.permission.BLUETOOTH_SCAN,
+            Manifest.permission.BLUETOOTH_ADVERTISE
+        )
     }
 }

--- a/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
+++ b/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
@@ -65,6 +65,7 @@ class MainActivity : ComponentActivity() {
         grantResults: IntArray
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        // keep existing logic
         if (requestCode != REQUEST_CODE_BLUETOOTH) {
             return
         }


### PR DESCRIPTION
## Summary
- request Android 12+ Bluetooth permissions before binding to the service
- start the service binding only after permissions are granted

## Testing
- ⚠️ `./gradlew :hub:assembleDebug` *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4c30f11dc8332962215a99576055b