### PR TITLE
Ensure Bluetooth permission flow also requests location

### DIFF
--- a/hub/src/main/java/io/texne/g1/hub/permissions/PermissionHelper.kt
+++ b/hub/src/main/java/io/texne/g1/hub/permissions/PermissionHelper.kt
@@ -11,14 +11,13 @@ object PermissionHelper {
 
     fun requiredPermissions(): Array<String> {
         val permissions = mutableListOf<String>()
+        permissions += Manifest.permission.ACCESS_FINE_LOCATION
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             permissions += Manifest.permission.BLUETOOTH_CONNECT
             permissions += Manifest.permission.BLUETOOTH_SCAN
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 permissions += Manifest.permission.POST_NOTIFICATIONS
             }
-        } else {
-            permissions += Manifest.permission.ACCESS_FINE_LOCATION
         }
         return permissions.toTypedArray()
     }


### PR DESCRIPTION
## Summary
- always include ACCESS_FINE_LOCATION in the Hub permission request list so it stays in sync with the service requirements on all Android versions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4e48ede10833294496381d4524291