### PR TITLE
Adjust status message subtitle for connected state

### DIFF
--- a/hub/src/main/java/io/texne/g1/hub/ui/scanner/ScannerScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/scanner/ScannerScreen.kt
@@ -249,6 +249,12 @@ private fun ServiceStatusBanner(
 
 @Composable
 private fun StatusMessageCard(message: String) {
+    val supportingText = when (message) {
+        "Connected" -> "You're connected to your glasses."
+        "Looking for glasses…", "Trying bonded connect…" ->
+            "We’ll automatically stop scanning once we connect."
+        else -> null
+    }
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -266,11 +272,13 @@ private fun StatusMessageCard(message: String) {
                 fontWeight = FontWeight.SemiBold,
                 color = Color.Black
             )
-            Text(
-                text = "We’ll automatically stop scanning once we connect.",
-                fontSize = 12.sp,
-                color = Color.Gray
-            )
+            if (!supportingText.isNullOrEmpty()) {
+                Text(
+                    text = supportingText,
+                    fontSize = 12.sp,
+                    color = Color.Gray
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- update the scanner status message card to show a connection-specific subtitle
- avoid showing the scanning subtitle when it does not apply to the current status

## Testing
- ./gradlew -p hub lint *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e52d36388332bb2ac2316a18cdcd