### PR TITLE
Make hub screens fill and scroll

### DIFF
--- a/hub/src/main/java/io/texne/g1/hub/ui/ApplicationFrame.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/ApplicationFrame.kt
@@ -120,45 +120,47 @@ fun ApplicationFrame(snackbarHostState: SnackbarHostState) {
 
         val connectedGlasses = state.connectedGlasses
 
-        when (selectedSection) {
-            AppSection.GLASSES -> {
-                if (connectedGlasses != null) {
-                    GlassesScreen(
-                        connectedGlasses,
-                        { viewModel.disconnect(connectedGlasses.id) }
-                    )
-                } else {
-                    ScannerScreen(
-                        scanning = state.scanning,
-                        error = state.error,
-                        serviceStatus = state.serviceStatus,
-                        nearbyGlasses = state.nearbyGlasses,
-                        retryCountdowns = state.retryCountdowns,
-                        statusMessage = state.statusMessage,
-                        errorMessage = state.errorMessage,
-                        scan = scanAction,
-                        connect = { viewModel.connect(it) },
-                        disconnect = { viewModel.disconnect(it) },
-                        cancelRetry = { viewModel.cancelAutoRetry(it) },
-                        retryNow = { viewModel.retryNow(it) },
-                        onBondedConnect = bondedConnectAction
+        Box(modifier = Modifier.weight(1f)) {
+            when (selectedSection) {
+                AppSection.GLASSES -> {
+                    if (connectedGlasses != null) {
+                        GlassesScreen(
+                            connectedGlasses,
+                            { viewModel.disconnect(connectedGlasses.id) }
+                        )
+                    } else {
+                        ScannerScreen(
+                            scanning = state.scanning,
+                            error = state.error,
+                            serviceStatus = state.serviceStatus,
+                            nearbyGlasses = state.nearbyGlasses,
+                            retryCountdowns = state.retryCountdowns,
+                            statusMessage = state.statusMessage,
+                            errorMessage = state.errorMessage,
+                            scan = scanAction,
+                            connect = { viewModel.connect(it) },
+                            disconnect = { viewModel.disconnect(it) },
+                            cancelRetry = { viewModel.cancelAutoRetry(it) },
+                            retryNow = { viewModel.retryNow(it) },
+                            onBondedConnect = bondedConnectAction
+                        )
+                    }
+                }
+                AppSection.TELEMETRY -> {
+                    TelemetryScreen(
+                        entries = state.telemetryEntries,
+                        onDisconnect = viewModel::disconnect
                     )
                 }
-            }
-            AppSection.TELEMETRY -> {
-                TelemetryScreen(
-                    entries = state.telemetryEntries,
-                    onDisconnect = viewModel::disconnect
-                )
-            }
-            AppSection.ASSISTANT -> {
-                ChatScreen(
-                    connectedGlassesName = connectedGlasses?.name,
-                    onNavigateToSettings = { viewModel.selectSection(AppSection.SETTINGS) }
-                )
-            }
-            AppSection.SETTINGS -> {
-                SettingsScreen()
+                AppSection.ASSISTANT -> {
+                    ChatScreen(
+                        connectedGlassesName = connectedGlasses?.name,
+                        onNavigateToSettings = { viewModel.selectSection(AppSection.SETTINGS) }
+                    )
+                }
+                AppSection.SETTINGS -> {
+                    SettingsScreen(modifier = Modifier.fillMaxSize())
+                }
             }
         }
     }

--- a/hub/src/main/java/io/texne/g1/hub/ui/settings/SettingsScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/settings/SettingsScreen.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Visibility
@@ -47,10 +49,12 @@ fun SettingsScreen(
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     var revealKey by rememberSaveable { mutableStateOf(false) }
+    val scrollState = rememberScrollState()
 
     Column(
         modifier = modifier
             .fillMaxSize()
+            .verticalScroll(scrollState)
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {


### PR DESCRIPTION
## Summary
- ensure the hub tab content fills the remaining viewport by wrapping it in a weighted Box
- make the settings tab vertically scrollable so long descriptions are no longer clipped

## Testing
- ./gradlew :hub:lint *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e770352c8332b6d136d8cfcc363c