### PR TITLE
Rebrand hub app with Eye of Kilrogg theme

### DIFF
--- a/hub/src/main/AndroidManifest.xml
+++ b/hub/src/main/AndroidManifest.xml
@@ -24,13 +24,13 @@
         android:name=".G1HubApplication"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.G1Hub"
+        android:theme="@style/Theme.EyeOfKilrogg"
         tools:targetApi="31" >
         <activity
             android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleInstance"
-            android:theme="@style/Theme.G1Hub">
+            android:theme="@style/Theme.EyeOfKilrogg">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -40,11 +40,11 @@
             android:name=".CrashActivity"
             android:exported="false"
             android:process=":crash"
-            android:theme="@style/Theme.G1Hub" />
+            android:theme="@style/Theme.EyeOfKilrogg" />
         <activity
             android:name=".permissions.PermissionActivity"
             android:exported="false"
-            android:theme="@style/Theme.G1Hub" />
+            android:theme="@style/Theme.EyeOfKilrogg" />
     </application>
 
 </manifest>

--- a/hub/src/main/java/io/texne/g1/hub/CrashActivity.kt
+++ b/hub/src/main/java/io/texne/g1/hub/CrashActivity.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.content.getSystemService
-import io.texne.g1.hub.ui.theme.G1HubTheme
+import io.texne.g1.hub.ui.theme.EyeOfKilroggTheme
 
 class CrashActivity : ComponentActivity() {
 
@@ -43,7 +43,7 @@ class CrashActivity : ComponentActivity() {
         val threadName = intent.getStringExtra(EXTRA_THREAD_NAME).orEmpty()
 
         setContent {
-            G1HubTheme {
+            EyeOfKilroggTheme {
                 CrashScreen(
                     threadName = threadName,
                     cause = cause,

--- a/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
+++ b/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.Modifier
 import dagger.hilt.android.AndroidEntryPoint
 import io.texne.g1.hub.model.Repository
 import io.texne.g1.hub.ui.ApplicationFrame
-import io.texne.g1.hub.ui.theme.G1HubTheme
+import io.texne.g1.hub.ui.theme.EyeOfKilroggTheme
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -40,7 +40,7 @@ class MainActivity : ComponentActivity() {
 
         enableEdgeToEdge()
         setContent {
-            G1HubTheme {
+            EyeOfKilroggTheme {
                 val snackbarHostState = remember { SnackbarHostState() }
                 Scaffold(
                     modifier = Modifier.fillMaxSize(),

--- a/hub/src/main/java/io/texne/g1/hub/ui/theme/Color.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/theme/Color.kt
@@ -2,10 +2,12 @@ package io.texne.g1.hub.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
-
-val Purple40 = Color(0xFF6650a4)
-val PurpleGrey40 = Color(0xFF625b71)
-val Pink40 = Color(0xFF7D5260)
+val OceanBlue = Color(0xFF1B3A4B)
+val MidnightBlue = Color(0xFF0D1B2A)
+val SkyTeal = Color(0xFF6EA9C9)
+val SunlitGold = Color(0xFFD8B36A)
+val BurnishedGold = Color(0xFF9B7B2D)
+val MistIvory = Color(0xFFF2E8CF)
+val SurfaceMist = Color(0xFFDDE5ED)
+val ShadowInk = Color(0xFF0A0F14)
+val MoonlightPearl = Color(0xFFF8F5E1)

--- a/hub/src/main/java/io/texne/g1/hub/ui/theme/Theme.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/theme/Theme.kt
@@ -11,32 +11,56 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 
 private val DarkColorScheme = darkColorScheme(
-    primary = Purple80,
-    secondary = PurpleGrey80,
-    tertiary = Pink80
+    primary = SkyTeal,
+    onPrimary = ShadowInk,
+    primaryContainer = OceanBlue,
+    onPrimaryContainer = MoonlightPearl,
+    secondary = SunlitGold,
+    onSecondary = ShadowInk,
+    secondaryContainer = BurnishedGold,
+    onSecondaryContainer = MoonlightPearl,
+    tertiary = SunlitGold,
+    onTertiary = ShadowInk,
+    tertiaryContainer = OceanBlue,
+    onTertiaryContainer = MoonlightPearl,
+    background = MidnightBlue,
+    onBackground = MoonlightPearl,
+    surface = OceanBlue,
+    onSurface = MoonlightPearl,
+    surfaceVariant = MidnightBlue,
+    onSurfaceVariant = MoonlightPearl,
+    outline = SunlitGold,
+    inversePrimary = MistIvory
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
-    secondary = PurpleGrey40,
-    tertiary = Pink40
-
-    /* Other default colors to override
-    background = Color(0xFFFFFBFE),
-    surface = Color(0xFFFFFBFE),
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onTertiary = Color.White,
-    onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-    */
+    primary = OceanBlue,
+    onPrimary = MoonlightPearl,
+    primaryContainer = SkyTeal,
+    onPrimaryContainer = ShadowInk,
+    secondary = SunlitGold,
+    onSecondary = ShadowInk,
+    secondaryContainer = BurnishedGold,
+    onSecondaryContainer = MoonlightPearl,
+    tertiary = SkyTeal,
+    onTertiary = ShadowInk,
+    tertiaryContainer = SurfaceMist,
+    onTertiaryContainer = OceanBlue,
+    background = MistIvory,
+    onBackground = ShadowInk,
+    surface = SurfaceMist,
+    onSurface = ShadowInk,
+    surfaceVariant = MistIvory,
+    onSurfaceVariant = OceanBlue,
+    outline = BurnishedGold,
+    inversePrimary = SkyTeal
 )
 
 @Composable
-fun G1HubTheme(
+fun EyeOfKilroggTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     // Dynamic color is available on Android 12+
-    dynamicColor: Boolean = true,
+    dynamicColor: Boolean = false,
     content: @Composable () -> Unit
 ) {
     val colorScheme = when {

--- a/hub/src/main/java/io/texne/g1/hub/ui/theme/Type.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/theme/Type.kt
@@ -6,29 +6,61 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
-// Set of Material typography styles to start with
+private val FantasySerif = FontFamily.Serif
+private val CompanionSans = FontFamily.SansSerif
+
 val Typography = Typography(
+    displayLarge = TextStyle(
+        fontFamily = FantasySerif,
+        fontWeight = FontWeight.Light,
+        fontSize = 57.sp,
+        lineHeight = 64.sp,
+        letterSpacing = (-0.25).sp
+    ),
+    headlineSmall = TextStyle(
+        fontFamily = FantasySerif,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 24.sp,
+        lineHeight = 30.sp
+    ),
+    titleLarge = TextStyle(
+        fontFamily = FantasySerif,
+        fontWeight = FontWeight.Medium,
+        fontSize = 22.sp,
+        lineHeight = 28.sp
+    ),
+    titleMedium = TextStyle(
+        fontFamily = FantasySerif,
+        fontWeight = FontWeight.Medium,
+        fontSize = 18.sp,
+        lineHeight = 24.sp
+    ),
     bodyLarge = TextStyle(
-        fontFamily = FontFamily.Default,
+        fontFamily = CompanionSans,
         fontWeight = FontWeight.Normal,
         fontSize = 16.sp,
         lineHeight = 24.sp,
-        letterSpacing = 0.5.sp
-    )
-    /* Other default text styles to override
-    titleLarge = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
-        fontSize = 22.sp,
-        lineHeight = 28.sp,
-        letterSpacing = 0.sp
+        letterSpacing = 0.3.sp
     ),
-    labelSmall = TextStyle(
-        fontFamily = FontFamily.Default,
+    bodyMedium = TextStyle(
+        fontFamily = CompanionSans,
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.25.sp
+    ),
+    bodySmall = TextStyle(
+        fontFamily = CompanionSans,
         fontWeight = FontWeight.Medium,
-        fontSize = 11.sp,
+        fontSize = 12.sp,
         lineHeight = 16.sp,
-        letterSpacing = 0.5.sp
+        letterSpacing = 0.2.sp
+    ),
+    labelLarge = TextStyle(
+        fontFamily = CompanionSans,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.1.sp
     )
-    */
 )

--- a/hub/src/main/res/values-night/themes.xml
+++ b/hub/src/main/res/values-night/themes.xml
@@ -1,16 +1,18 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <!-- Base application theme. -->
-    <style name="Theme.G1Hub" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
-        <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/purple_200</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
-        <item name="colorOnPrimary">@color/black</item>
-        <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_200</item>
-        <item name="colorOnSecondary">@color/black</item>
-        <!-- Status bar color. -->
-        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
-        <!-- Customize your theme here. -->
+    <style name="Theme.EyeOfKilrogg" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="colorPrimary">@color/kilrogg_sky</item>
+        <item name="colorPrimaryVariant">@color/kilrogg_ocean</item>
+        <item name="colorOnPrimary">@color/kilrogg_shadow</item>
+        <item name="colorSecondary">@color/kilrogg_glow</item>
+        <item name="colorSecondaryVariant">@color/kilrogg_glow_dark</item>
+        <item name="colorOnSecondary">@color/kilrogg_shadow</item>
+        <item name="colorSurface">@color/kilrogg_ocean</item>
+        <item name="colorOnSurface">@color/kilrogg_text_light</item>
+        <item name="colorBackground">@color/kilrogg_depths</item>
+        <item name="colorOnBackground">@color/kilrogg_text_light</item>
+        <item name="android:statusBarColor">@color/kilrogg_depths</item>
+        <item name="android:navigationBarColor">@color/kilrogg_depths</item>
+        <item name="android:windowBackground">@color/kilrogg_depths</item>
+        <item name="android:windowLightStatusBar">false</item>
     </style>
 </resources>

--- a/hub/src/main/res/values/colors.xml
+++ b/hub/src/main/res/values/colors.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="purple_200">#FFBB86FC</color>
-    <color name="purple_500">#FF6200EE</color>
-    <color name="purple_700">#FF3700B3</color>
-    <color name="teal_200">#FF03DAC5</color>
-    <color name="teal_700">#FF018786</color>
-    <color name="black">#FF000000</color>
-    <color name="white">#FFFFFFFF</color>
+    <color name="kilrogg_ocean">#FF1B3A4B</color>
+    <color name="kilrogg_depths">#FF0D1B2A</color>
+    <color name="kilrogg_sky">#FF6EA9C9</color>
+    <color name="kilrogg_glow">#FFD8B36A</color>
+    <color name="kilrogg_glow_dark">#FF9B7B2D</color>
+    <color name="kilrogg_ivory">#FFF2E8CF</color>
+    <color name="kilrogg_surface_mist">#FFDDE5ED</color>
+    <color name="kilrogg_shadow">#FF0A0F14</color>
+    <color name="kilrogg_text_light">#FFF8F5E1</color>
+    <color name="kilrogg_text_dark">#FF13212B</color>
 </resources>

--- a/hub/src/main/res/values/strings.xml
+++ b/hub/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">G1 Hub</string>
+    <string name="app_name">Eye of Kilrogg</string>
     <string name="settings_assistant_activation_title">Assistant activation</string>
     <string name="settings_assistant_activation_description">Choose how to open the assistant from your glasses.</string>
     <string name="settings_assistant_activation_option_off">Off</string>

--- a/hub/src/main/res/values/themes.xml
+++ b/hub/src/main/res/values/themes.xml
@@ -1,16 +1,19 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.G1Hub" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
-        <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/purple_500</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
-        <item name="colorOnPrimary">@color/white</item>
-        <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_700</item>
-        <item name="colorOnSecondary">@color/black</item>
-        <!-- Status bar color. -->
-        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
-        <!-- Customize your theme here. -->
+    <style name="Theme.EyeOfKilrogg" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="colorPrimary">@color/kilrogg_ocean</item>
+        <item name="colorPrimaryVariant">@color/kilrogg_depths</item>
+        <item name="colorOnPrimary">@color/kilrogg_text_light</item>
+        <item name="colorSecondary">@color/kilrogg_glow</item>
+        <item name="colorSecondaryVariant">@color/kilrogg_glow_dark</item>
+        <item name="colorOnSecondary">@color/kilrogg_text_dark</item>
+        <item name="colorSurface">@color/kilrogg_surface_mist</item>
+        <item name="colorOnSurface">@color/kilrogg_text_dark</item>
+        <item name="colorBackground">@color/kilrogg_ivory</item>
+        <item name="colorOnBackground">@color/kilrogg_text_dark</item>
+        <item name="android:statusBarColor">@color/kilrogg_depths</item>
+        <item name="android:navigationBarColor">@color/kilrogg_depths</item>
+        <item name="android:windowBackground">@color/kilrogg_ivory</item>
+        <item name="android:windowLightStatusBar">false</item>
     </style>
 </resources>


### PR DESCRIPTION
## Summary
- rename the app to Eye of Kilrogg and retarget Android resources to the new theme name
- retheme the day and night palettes with Breath of Fire IV-inspired colors and disable dynamic theming to keep the look consistent
- refresh Compose typography to use system serif and sans-serif families for a fantasy flavor

## Testing
- ./gradlew :hub:assembleDebug *(fails: Android SDK is not configured in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e84aa6288332876678cf76d6328e