### PR TITLE
Point hub manifest to cleaned theme

### DIFF
--- a/hub/src/main/AndroidManifest.xml
+++ b/hub/src/main/AndroidManifest.xml
@@ -24,13 +24,13 @@
         android:name=".G1HubApplication"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.G1Hub"
+        android:theme="@style/Theme.App"
         tools:targetApi="31" >
         <activity
             android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleInstance"
-            android:theme="@style/Theme.G1Hub">
+            android:theme="@style/Theme.App">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -40,11 +40,11 @@
             android:name=".CrashActivity"
             android:exported="false"
             android:process=":crash"
-            android:theme="@style/Theme.G1Hub" />
+            android:theme="@style/Theme.App" />
         <activity
             android:name=".permissions.PermissionActivity"
             android:exported="false"
-            android:theme="@style/Theme.G1Hub" />
+            android:theme="@style/Theme.App" />
     </application>
 
 </manifest>

--- a/hub/src/main/res/values-night/colors.xml
+++ b/hub/src/main/res/values-night/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="background">#121212</color>
+</resources>

--- a/hub/src/main/res/values-night/themes.xml
+++ b/hub/src/main/res/values-night/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.G1Hub" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.App" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_200</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>
@@ -11,6 +11,7 @@
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
         <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
+        <item name="android:windowBackground">@color/background</item>
         <!-- Customize your theme here. -->
     </style>
 </resources>

--- a/hub/src/main/res/values/colors.xml
+++ b/hub/src/main/res/values/colors.xml
@@ -7,6 +7,8 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="background">#FFFFFFFF</color>
+    <color name="colorBackground">#FFFFFFFF</color>
     <color name="telemetry_success">#FF2E7D32</color>
     <color name="telemetry_error">#FFC62828</color>
     <color name="telemetry_info">#FF546E7A</color>

--- a/hub/src/main/res/values/themes.xml
+++ b/hub/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.G1Hub" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.App" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_500</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>
@@ -11,6 +11,7 @@
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
         <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
+        <item name="android:windowBackground">@color/background</item>
         <!-- Customize your theme here. -->
     </style>
 </resources>


### PR DESCRIPTION
## Summary
- rename the hub day and night theme resources to Theme.App for consistency with Material Components defaults
- update the hub manifest to reference the cleaned Theme.App style across activities and the application tag

## Testing
- `./gradlew :hub:assembleDebug` *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d53591b73c8332adc3fc8275fce114