### PR TITLE
Bind hub service asynchronously

### DIFF
--- a/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
+++ b/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
@@ -5,6 +5,7 @@ import android.app.Activity
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
@@ -27,7 +28,11 @@ import io.texne.g1.hub.ui.GlassesAdapter
 import io.texne.g1.hub.ui.TelemetryEntryAdapter
 import io.texne.g1.hub.ui.TelemetryLogAdapter
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -40,7 +45,7 @@ class MainActivity : ComponentActivity() {
 
     private val glassesAdapter = GlassesAdapter(object : GlassesAdapter.GlassesActionListener {
         override fun onConnect(id: String) {
-            runWithPermissions { viewModel.connect(id) }
+            runWithPermissions("glassesConnect:$id") { viewModel.connect(id) }
         }
 
         override fun onDisconnect(id: String) {
@@ -52,7 +57,7 @@ class MainActivity : ComponentActivity() {
         }
 
         override fun onRetryNow(id: String) {
-            runWithPermissions { viewModel.retryNow(id) }
+            runWithPermissions("glassesRetry:$id") { viewModel.retryNow(id) }
         }
     })
 
@@ -61,27 +66,26 @@ class MainActivity : ComponentActivity() {
 
     private var pendingPermissionAction: (() -> Unit)? = null
     private var autoPromptShown = false
+    private var serviceBound = false
+    private var bindJob: Job? = null
 
     private val permissionLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             val action = pendingPermissionAction
             pendingPermissionAction = null
             if (result.resultCode == Activity.RESULT_OK) {
+                Log.i(TAG, "Permission helper result OK; running pending action")
+                bindServiceIfPossible("permissionHelperResult")
                 action?.invoke()
             } else {
+                Log.w(TAG, "Permission helper canceled; notifying ViewModel")
                 viewModel.onPermissionDenied()
             }
         }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        if (hasBluetoothPermissions()) {
-            repository.bindService()
-        } else {
-            requestBluetoothPermissions()
-        }
-
+        Log.i(TAG, "onCreate")
         enableEdgeToEdge()
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
@@ -94,10 +98,10 @@ class MainActivity : ComponentActivity() {
         binding.recyclerTelemetryLogs.adapter = telemetryLogAdapter
 
         binding.buttonScan.setOnClickListener {
-            runWithPermissions { viewModel.scan() }
+            runWithPermissions("manualScan") { viewModel.scan() }
         }
         binding.buttonBondedConnect.setOnClickListener {
-            runWithPermissions { viewModel.tryBondedConnect() }
+            runWithPermissions("bondedConnectButton") { viewModel.tryBondedConnect() }
         }
 
         val glassesLabel = if (viewModel.glasses.isBlank()) {
@@ -139,9 +143,19 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    override fun onStart() {
+        super.onStart()
+        bindServiceIfPossible("onStart")
+    }
+
     override fun onDestroy() {
         super.onDestroy()
-        repository.unbindService()
+        bindJob?.cancel()
+        if (serviceBound) {
+            Log.i(TAG, "Unbinding service in onDestroy")
+            repository.unbindService()
+            serviceBound = false
+        }
     }
 
     override fun onRequestPermissionsResult(
@@ -157,7 +171,11 @@ class MainActivity : ComponentActivity() {
                 grantResults.all { it == PackageManager.PERMISSION_GRANTED }
 
         if (bluetoothPermissionsGranted) {
-            repository.bindService()
+            Log.i(TAG, "Bluetooth permissions granted via ActivityCompat; binding service")
+            bindServiceIfPossible("runtimePermissionResult")
+        } else {
+            Log.w(TAG, "Bluetooth permissions denied via ActivityCompat")
+            viewModel.onPermissionDenied()
         }
     }
 
@@ -199,7 +217,7 @@ class MainActivity : ComponentActivity() {
         if (state.serviceStatus == G1ServiceCommon.ServiceStatus.PERMISSION_REQUIRED) {
             if (!autoPromptShown) {
                 autoPromptShown = true
-                runWithPermissions { }
+                runWithPermissions("autoPrompt") { }
             }
         } else {
             autoPromptShown = false
@@ -225,17 +243,23 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    private fun runWithPermissions(action: () -> Unit) {
+    private fun runWithPermissions(trigger: String, action: () -> Unit) {
         val intent = PermissionHelper.createPermissionIntent(this)
         if (intent == null) {
+            Log.d(TAG, "Permission helper intent unavailable; executing immediately (trigger=$trigger)")
             action()
             return
         }
         if (pendingPermissionAction == null) {
+            Log.i(TAG, "Launching permission helper intent (trigger=$trigger)")
             pendingPermissionAction = action
             permissionLauncher.launch(intent)
+        } else {
+            Log.d(TAG, "Pending permission action already queued; ignoring trigger=$trigger")
         }
     }
+
+    private fun runWithPermissions(action: () -> Unit) = runWithPermissions("unspecified", action)
 
     private fun hasBluetoothPermissions(): Boolean {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
@@ -247,13 +271,63 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    private fun requestBluetoothPermissions() {
+    private fun requestBluetoothPermissions(trigger: String) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            Log.i(TAG, "Requesting Bluetooth runtime permissions (trigger=$trigger)")
             ActivityCompat.requestPermissions(this, BLUETOOTH_PERMISSIONS, REQUEST_CODE_BLUETOOTH)
         }
     }
 
+    private fun requestBluetoothPermissions() = requestBluetoothPermissions("unknown")
+
+    private fun bindServiceIfPossible(trigger: String) {
+        val hasPermissions = hasBluetoothPermissions()
+        Log.d(
+            TAG,
+            "bindServiceIfPossible(trigger=$trigger, hasPermissions=$hasPermissions, serviceBound=$serviceBound)"
+        )
+        if (hasPermissions) {
+            if (serviceBound) {
+                Log.d(TAG, "Service already bound (trigger=$trigger)")
+            } else if (bindJob?.isActive == true) {
+                Log.d(TAG, "Service bind already in progress (trigger=$trigger)")
+            } else {
+                val job = lifecycleScope.launch {
+                    val bound = withContext(Dispatchers.IO) {
+                        runCatching { repository.bindService() }
+                            .onFailure { error ->
+                                Log.e(TAG, "Service bind threw (trigger=$trigger)", error)
+                            }
+                            .getOrDefault(false)
+                    }
+                    serviceBound = bound
+                    Log.i(
+                        TAG,
+                        if (serviceBound) {
+                            "Service bind succeeded (trigger=$trigger)"
+                        } else {
+                            "Service bind failed (trigger=$trigger)"
+                        }
+                    )
+                }
+                bindJob = job
+                job.invokeOnCompletion { error ->
+                    bindJob = null
+                    if (error != null && error !is CancellationException) {
+                        Log.e(TAG, "Service bind coroutine failed (trigger=$trigger)", error)
+                    }
+                }
+            }
+        } else {
+            Log.w(TAG, "Missing Bluetooth permissions; requesting (trigger=$trigger)")
+            requestBluetoothPermissions(trigger)
+        }
+    }
+
+    private fun bindServiceIfPossible() = bindServiceIfPossible("unknown")
+
     private companion object {
+        private const val TAG = "MainActivity"
         private const val REQUEST_CODE_BLUETOOTH = 0x42
         private val BLUETOOTH_PERMISSIONS = arrayOf(
             Manifest.permission.BLUETOOTH_CONNECT,


### PR DESCRIPTION
## Summary
- prevent the splash screen freeze by moving repository.bindService work onto a lifecycle coroutine instead of the main thread
- guard against duplicate bind attempts while one is in flight and surface failures through structured logs

## Testing
- `./gradlew :hub:assembleDebug` *(fails: Android SDK is not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d63aee7aa88332ac7689283a81bd92